### PR TITLE
Add battle timers, HP, block-effect combat and pixel sprites

### DIFF
--- a/assets/match3.css
+++ b/assets/match3.css
@@ -38,3 +38,24 @@ button:disabled { opacity: .55; cursor: not-allowed; }
 @keyframes spawn { from { opacity: 0; transform: translateY(var(--from-y)) scale(.75); } to { opacity: 1; transform: translateY(0) scale(1); } }
 @keyframes pulse { 50% { transform: scale(1.15); box-shadow: 0 0 0 5px #fde68a, inset 0 -7px 0 rgba(0,0,0,.12); } }
 @media (max-width: 820px) { :root { --cell-size: 36px; --gap: 4px; } .game-layout { grid-template-columns: 1fr; } .stats { grid-template-columns: repeat(2, 1fr); } .board { margin: 0 auto; } }
+.stats { grid-template-columns: repeat(9, minmax(96px, 1fr)); }
+.cell { position: relative; display: grid; place-items: center; font-size: 22px; text-shadow: 0 2px 0 rgba(0,0,0,.18); }
+.cell-icon { pointer-events: none; filter: drop-shadow(0 2px 0 rgba(255,255,255,.22)); }
+.battle-stage { display: grid; grid-template-columns: 1fr auto 1fr; align-items: end; gap: 12px; padding: 16px; margin-bottom: 14px; border-radius: 16px; background: linear-gradient(#dbeafe, #f8fafc); border: 2px solid rgba(59,130,246,.18); }
+.fighter { display: grid; justify-items: center; gap: 8px; font-weight: 800; }
+.versus { align-self: center; color: #ef4444; font-weight: 900; letter-spacing: .08em; }
+.pixel-sprite { position: relative; width: 54px; height: 72px; image-rendering: pixelated; animation: idle-bob 900ms steps(2, end) infinite; }
+.pixel-sprite::before { content: ''; position: absolute; left: 17px; top: 4px; width: 20px; height: 20px; background: #f8c38a; box-shadow: 0 20px 0 #2563eb, -10px 28px 0 #1d4ed8, 10px 28px 0 #1d4ed8, -8px 48px 0 #334155, 8px 48px 0 #334155, 0 -6px 0 #7c2d12; }
+.pixel-sprite::after { content: ''; position: absolute; left: 39px; top: 30px; width: 8px; height: 28px; background: #f59e0b; transform-origin: top center; box-shadow: 0 22px 0 #92400e; }
+.enemy-sprite { transform: scaleX(-1); filter: hue-rotate(145deg) saturate(1.2); }
+.hero-sprite.attacking { animation: hero-attack 520ms steps(3, end); }
+.enemy-sprite.attacking { animation: enemy-attack 520ms steps(3, end); }
+.hero-sprite.attacking::after, .enemy-sprite.attacking::after { transform: rotate(-55deg); }
+.effect-grid { display: grid; grid-template-columns: repeat(2, minmax(120px, 1fr)); gap: 8px; margin-bottom: 12px; }
+.effect-grid span, .battle-log { border-radius: 12px; background: #f8fafc; border: 1px solid #e2e8f0; padding: 10px; font-weight: 700; }
+.battle-log { color: #7c2d12; background: #fff7ed; }
+@keyframes idle-bob { 50% { transform: translateY(-3px); } }
+@keyframes hero-attack { 50% { transform: translateX(18px); } }
+@keyframes enemy-attack { 50% { transform: scaleX(-1) translateX(18px); } }
+@media (max-width: 980px) { .stats { grid-template-columns: repeat(3, 1fr); } }
+@media (max-width: 820px) { .stats { grid-template-columns: repeat(2, 1fr); } .effect-grid { grid-template-columns: 1fr; } }

--- a/assets/match3.ui.js
+++ b/assets/match3.ui.js
@@ -1,11 +1,32 @@
 (function () {
-  const COLORS = ['#FF6663', '#FEB144', '#9EE09E', '#9EC1CF', '#CC99C9', '#B5EAD7', '#C7CEEA'];
+  const BLOCK_TYPES = [
+    { name: '攻擊', icon: '⚔', color: '#FF6663', stat: 'attack' },
+    { name: '防禦', icon: '🛡', color: '#60A5FA', stat: 'defense' },
+    { name: '法術', icon: '✦', color: '#A78BFA', stat: 'spell' },
+    { name: '回血', icon: '❤', color: '#34D399', stat: 'heal' },
+    { name: '火焰', icon: '🔥', color: '#FEB144', stat: 'attack' },
+    { name: '自然', icon: '☘', color: '#9EE09E', stat: 'heal' },
+    { name: '星光', icon: '★', color: '#FDE68A', stat: 'spell' }
+  ];
   const logic = window.Match3Logic;
   const $ = id => document.getElementById(id);
-  const state = { board: [], size: 8, colorCount: 4, fallSpeed: 420, clearSpeed: 260, selected: null, busy: false, score: 0, moves: 30, target: 1200, combo: 1, startedAt: null, timerId: null, hint: [] };
+  const DEFAULT_HP = 10;
+  const ENEMY_ATTACK = 10;
+  const state = {
+    board: [], size: 8, colorCount: 4, fallSpeed: 420, clearSpeed: 260,
+    selected: null, busy: false, score: 0, moves: 30, target: 1200, combo: 1,
+    startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null,
+    hint: [], playerHp: DEFAULT_HP, enemyHp: DEFAULT_HP, maxHp: DEFAULT_HP,
+    attackInterval: 5, enemyInterval: 5, nextPlayerAttackAt: null, nextEnemyAttackAt: null,
+    roundStats: { attack: 0, defense: 0, spell: 0, heal: 0 },
+    lastAction: '尚未攻擊。', heroAction: false, enemyAction: false, ended: false
+  };
 
   function key(pos) { return `${pos.r},${pos.c}`; }
   function sleep(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }
+  function clamp(value, min, max) { return Math.max(min, Math.min(max, value)); }
+  function blockType(value) { return BLOCK_TYPES[value % BLOCK_TYPES.length]; }
+  function sleepMsFromSeconds(seconds) { return Math.max(1, Number(seconds)) * 1000; }
   function cellPixels() {
     const root = getComputedStyle(document.documentElement);
     return parseFloat(root.getPropertyValue('--cell-size')) + parseFloat(root.getPropertyValue('--gap'));
@@ -30,7 +51,11 @@
       div.setAttribute('aria-label', `第 ${r + 1} 列第 ${c + 1} 欄`);
       if (value === null) div.classList.add('empty');
       else {
-        div.style.background = COLORS[value];
+        const type = blockType(value);
+        div.style.background = type.color;
+        div.dataset.type = type.stat;
+        div.innerHTML = `<span class="cell-icon" aria-hidden="true">${type.icon}</span>`;
+        div.title = type.name;
         div.addEventListener('click', () => handleCellClick(pos));
       }
       if (state.selected && state.selected.r === r && state.selected.c === c) div.classList.add('selected');
@@ -51,25 +76,51 @@
     $('moves').textContent = state.moves;
     $('target').textContent = state.target;
     $('combo').textContent = `x${state.combo}`;
-    $('hintButton').disabled = state.busy;
+    $('playerHp').textContent = `${state.playerHp}/${state.maxHp}`;
+    $('enemyHp').textContent = `${state.enemyHp}/${state.maxHp}`;
+    $('playerAttackCountdown').textContent = formatCountdown(state.nextPlayerAttackAt);
+    $('enemyAttackCountdown').textContent = formatCountdown(state.nextEnemyAttackAt);
+    $('roundAttack').textContent = state.roundStats.attack;
+    $('roundDefense').textContent = state.roundStats.defense;
+    $('roundSpell').textContent = state.roundStats.spell;
+    $('roundHeal').textContent = state.roundStats.heal;
+    $('battleLog').textContent = state.lastAction;
+    $('heroSprite').classList.toggle('attacking', state.heroAction);
+    $('enemySprite').classList.toggle('attacking', state.enemyAction);
+    $('hintButton').disabled = state.busy || state.ended;
     $('resetButton').disabled = state.busy;
   }
 
+  function formatCountdown(target) {
+    if (!target || state.ended) return '--';
+    return `${Math.max(0, Math.ceil((target - Date.now()) / 1000))}s`;
+  }
   function setStatus(text) { $('status').textContent = text; }
   function updateTimer() {
     if (!state.startedAt) { $('timer').textContent = '00:00'; return; }
     const sec = Math.floor((Date.now() - state.startedAt) / 1000);
     $('timer').textContent = `${String(Math.floor(sec / 60)).padStart(2, '0')}:${String(sec % 60).padStart(2, '0')}`;
+    render();
   }
-  function startTimer() {
-    if (state.startedAt) return;
+  function startTimers() {
+    if (state.startedAt || state.ended) return;
     state.startedAt = Date.now();
+    state.nextPlayerAttackAt = Date.now() + sleepMsFromSeconds(state.attackInterval);
+    state.nextEnemyAttackAt = Date.now() + sleepMsFromSeconds(state.enemyInterval);
     state.timerId = setInterval(updateTimer, 1000);
+    state.attackTimerId = setInterval(playerAttack, sleepMsFromSeconds(state.attackInterval));
+    state.enemyTimerId = setInterval(enemyAttack, sleepMsFromSeconds(state.enemyInterval));
+  }
+  function stopTimers() {
+    clearInterval(state.timerId); clearInterval(state.attackTimerId); clearInterval(state.enemyTimerId);
   }
 
+  function resetRoundStats() { state.roundStats = { attack: 0, defense: 0, spell: 0, heal: 0 }; }
+
   function resetGame() {
-    clearInterval(state.timerId);
-    Object.assign(state, { size: Number($('boardSize').value), colorCount: Number($('colorCount').value), fallSpeed: Number($('fallSpeed').value), clearSpeed: Number($('clearSpeed').value), selected: null, busy: false, score: 0, moves: 30, target: Number($('boardSize').value) * 150, combo: 1, startedAt: null, timerId: null, hint: [] });
+    stopTimers();
+    Object.assign(state, { size: Number($('boardSize').value), colorCount: Number($('colorCount').value), fallSpeed: Number($('fallSpeed').value), clearSpeed: Number($('clearSpeed').value), attackInterval: Number($('attackInterval').value), enemyInterval: Number($('enemyInterval').value), selected: null, busy: false, score: 0, moves: 30, target: Number($('boardSize').value) * 150, combo: 1, startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null, hint: [], playerHp: DEFAULT_HP, enemyHp: DEFAULT_HP, maxHp: DEFAULT_HP, nextPlayerAttackAt: null, nextEnemyAttackAt: null, lastAction: '交換方塊後，雙方攻擊計時器會開始。', heroAction: false, enemyAction: false, ended: false });
+    resetRoundStats();
     state.board = logic.createBoard(state.size, state.colorCount);
     updateTimer();
     setStatus('請交換相鄰方塊開始遊戲。');
@@ -77,12 +128,12 @@
   }
 
   async function handleCellClick(pos) {
-    if (state.busy || state.moves <= 0) return;
+    if (state.busy || state.moves <= 0 || state.ended) return;
     state.hint = [];
     if (!state.selected) { state.selected = pos; render(); return; }
     if (!logic.areAdjacent(state.selected, pos)) { state.selected = pos; render(); return; }
 
-    startTimer();
+    startTimers();
     state.busy = true;
     const previous = state.board;
     state.board = logic.swap(state.board, state.selected, pos);
@@ -109,7 +160,11 @@
   async function resolveMatches() {
     let matches = logic.findMatches(state.board);
     while (matches.length > 0) {
-      setStatus(`消除 ${matches.length} 個方塊！`);
+      setStatus(`消除 ${matches.length} 個方塊，效果已累積到本輪計時器。`);
+      matches.forEach(({ r, c }) => {
+        const type = blockType(state.board[r][c]);
+        state.roundStats[type.stat] += 1;
+      });
       state.score += matches.length * 20 * state.combo;
       render({ clearing: matches });
       await sleep(state.clearSpeed);
@@ -123,19 +178,60 @@
     }
   }
 
+  function flashActor(actor) {
+    if (actor === 'hero') state.heroAction = true;
+    else state.enemyAction = true;
+    render();
+    setTimeout(() => { if (actor === 'hero') state.heroAction = false; else state.enemyAction = false; render(); }, 550);
+  }
+
+  function playerAttack() {
+    if (state.ended) return;
+    const damage = state.roundStats.attack + (state.roundStats.spell * 2);
+    const heal = state.roundStats.heal;
+    state.enemyHp = clamp(state.enemyHp - damage, 0, state.maxHp);
+    state.playerHp = clamp(state.playerHp + heal, 0, state.maxHp);
+    state.lastAction = `我方攻擊造成 ${damage} 傷害，回血 ${heal}。防禦會保留到敵方攻擊結算。`;
+    state.roundStats.attack = 0;
+    state.roundStats.spell = 0;
+    state.roundStats.heal = 0;
+    state.nextPlayerAttackAt = Date.now() + sleepMsFromSeconds(state.attackInterval);
+    flashActor('hero');
+    checkBattleEnd();
+  }
+
+  function enemyAttack() {
+    if (state.ended) return;
+    const blocked = Math.min(ENEMY_ATTACK, state.roundStats.defense);
+    const damage = ENEMY_ATTACK - blocked;
+    state.playerHp = clamp(state.playerHp - damage, 0, state.maxHp);
+    state.lastAction = `敵方攻擊 ${ENEMY_ATTACK}，防禦方塊抵擋 ${blocked}，我方受到 ${damage} 傷害。`;
+    resetRoundStats();
+    state.nextEnemyAttackAt = Date.now() + sleepMsFromSeconds(state.enemyInterval);
+    flashActor('enemy');
+    checkBattleEnd();
+  }
+
+  function checkBattleEnd() {
+    if (state.enemyHp <= 0) { state.ended = true; stopTimers(); setStatus('勝利！敵方血量歸零。'); }
+    if (state.playerHp <= 0) { state.ended = true; stopTimers(); setStatus('失敗！我方血量歸零。'); }
+    render();
+  }
+
   function endTurnCheck() {
-    if (state.score >= state.target) { setStatus('恭喜過關！你達成目標分數了。'); return; }
+    if (state.ended) return;
+    if (state.score >= state.target) { setStatus('恭喜達成目標分數，也可以繼續打倒敵人。'); return; }
     if (state.moves <= 0) { setStatus('步數用完，請重設再挑戰一次。'); return; }
     if (!logic.findAvailableMove(state.board)) {
       state.board = logic.shuffleBoard(state.board);
       setStatus('棋盤沒有可走步了，已自動重排。');
     } else {
-      setStatus('請繼續交換相鄰方塊。');
+      setStatus('請繼續交換相鄰方塊並累積攻擊、防禦、法術與回血。');
     }
   }
 
   function showHint() {
-    if (state.busy) return;
+    if (state.busy || state.ended) return;
     const move = logic.findAvailableMove(state.board);
     state.hint = move || [];
     setStatus(move ? '已標出一組可交換的方塊。' : '目前無解，已重新排列棋盤。');
@@ -146,6 +242,8 @@
   ['colorCount', 'boardSize'].forEach(id => $(id).addEventListener('change', resetGame));
   $('fallSpeed').addEventListener('change', e => { state.fallSpeed = Number(e.target.value); render(); });
   $('clearSpeed').addEventListener('change', e => { state.clearSpeed = Number(e.target.value); render(); });
+  $('attackInterval').addEventListener('change', resetGame);
+  $('enemyInterval').addEventListener('change', resetGame);
   $('resetButton').addEventListener('click', resetGame);
   $('hintButton').addEventListener('click', showHint);
   resetGame();

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <section class="hero">
       <p class="eyebrow">Match-3 Puzzle Game</p>
       <h1>簡易三消遊戲</h1>
-      <p class="subtitle">點選相鄰方塊交換，湊成 3 個以上同色方塊即可消除。開場會保持靜止，只有玩家操作後才會開始結算。</p>
+      <p class="subtitle">點選相鄰方塊交換，湊成 3 個以上同色方塊即可消除。現在每種方塊都有戰鬥效果，並會依照雙方攻擊計時器進行結算。</p>
     </section>
 
     <section class="panel controls" aria-label="遊戲設定">
@@ -37,6 +37,12 @@
       <label>消除速度(ms)
         <input type="number" id="clearSpeed" value="260" min="80" max="1000" step="10" />
       </label>
+      <label>我方攻擊頻率(秒)
+        <input type="number" id="attackInterval" value="5" min="1" max="30" step="1" />
+      </label>
+      <label>敵方攻擊頻率(秒)
+        <input type="number" id="enemyInterval" value="5" min="1" max="30" step="1" />
+      </label>
       <button id="resetButton" type="button">重設遊戲</button>
       <button id="hintButton" type="button" class="secondary">提示</button>
     </section>
@@ -47,18 +53,39 @@
       <article><span>目標</span><strong id="target">1200</strong></article>
       <article><span>時間</span><strong id="timer">00:00</strong></article>
       <article><span>連鎖</span><strong id="combo">x1</strong></article>
+      <article><span>我方血量</span><strong id="playerHp">10/10</strong></article>
+      <article><span>敵方血量</span><strong id="enemyHp">10/10</strong></article>
+      <article><span>我方攻擊</span><strong id="playerAttackCountdown">--</strong></article>
+      <article><span>敵方攻擊</span><strong id="enemyAttackCountdown">--</strong></article>
     </section>
 
     <section class="game-layout">
       <div id="board" class="board" aria-label="三消遊戲棋盤"></div>
       <aside class="panel business-panel">
-        <h2>商業化常見功能</h2>
+        <h2>戰鬥狀態</h2>
+        <div class="battle-stage" aria-label="角色戰鬥展示">
+          <div class="fighter hero-fighter">
+            <div id="heroSprite" class="pixel-sprite hero-sprite" aria-label="我方像素角色"></div>
+            <strong>我方</strong>
+          </div>
+          <div class="versus">VS</div>
+          <div class="fighter enemy-fighter">
+            <div id="enemySprite" class="pixel-sprite enemy-sprite" aria-label="敵方像素角色"></div>
+            <strong>敵方</strong>
+          </div>
+        </div>
+        <div class="effect-grid" aria-label="本輪累積效果">
+          <span>⚔ 攻擊 <strong id="roundAttack">0</strong></span>
+          <span>🛡 防禦 <strong id="roundDefense">0</strong></span>
+          <span>✦ 法術 <strong id="roundSpell">0</strong></span>
+          <span>❤ 回血 <strong id="roundHeal">0</strong></span>
+        </div>
         <ul>
-          <li>分數、目標分、剩餘步數與計時。</li>
-          <li>提示按鈕與無解自動重排。</li>
-          <li>勝利 / 失敗狀態提示。</li>
-          <li>動畫速度可調，方便做關卡難度。</li>
+          <li>預設方塊效果：攻擊、防禦、法術、回血。</li>
+          <li>我方攻擊時間到時，會用攻擊與法術傷害攻擊敵方，回血方塊會回復我方血量。</li>
+          <li>敵方攻擊預設 10，會扣掉本輪防禦方塊，剩餘傷害扣我方血量。</li>
         </ul>
+        <p id="battleLog" class="battle-log">尚未攻擊。</p>
         <p id="status" class="status">請交換相鄰方塊開始遊戲。</p>
       </aside>
     </section>


### PR DESCRIPTION
### Motivation
- 將三消遊戲擴展成帶有簡易戰鬥系統，讓消除方塊的效果能累積並在週期性計時器到時觸發攻擊或防禦結算。 
- 顯示雙方血量並可調整攻擊頻率以便做回合式/時間制的互動設計。 

### Description
- 新增可設定的攻擊頻率輸入 `attackInterval` 與 `enemyInterval`（預設 `5` 秒），並在 UI 顯示倒數 `playerAttackCountdown` / `enemyAttackCountdown`，變更位於 `index.html`。 
- 新增玩家與敵方血量顯示 `playerHp` / `enemyHp`（預設 `10/10`），以及本輪累積效果 `roundAttack` / `roundDefense` / `roundSpell` / `roundHeal`，變更位於 `index.html` 與 `assets/match3.ui.js`。 
- 把方塊改為帶有類型 `attack` / `defense` / `spell` / `heal`（`BLOCK_TYPES`），在 `resolveMatches` 時把被消除方塊的效果累計到 `state.roundStats`，變更於 `assets/match3.ui.js`。 
- 新增定時器驅動的戰鬥結算：當我方計時器到會以 `attack + spell*2` 對敵方造成傷害並處理回血；敵方攻擊預設為 `10`，會先被本輪防禦值抵擋，剩餘傷害扣玩家血量；計時器與結算函式在 `assets/match3.ui.js` 中新增 `startTimers` / `playerAttack` / `enemyAttack` / `checkBattleEnd` 與相關狀態欄位。 
- 加入簡單像素風角色顯示與攻擊動畫（透過 `.pixel-sprite` 與 `attacking` class 切換），以及戰鬥文字紀錄區 `battleLog`，樣式變更於 `assets/match3.css`。 

### Testing
- 已使用 `node --check assets/match3.ui.js` 檢查腳本語法，結果成功。 
- 已用 `python3 -m http.server` 啟動靜態伺服器並以 `curl` 驗證頁面中包含 `playerHp`、`enemyHp`、`attackInterval`、`enemyInterval`、`battle-stage` 與 `roundAttack` 等新增節點，結果成功。 
- 嘗試用 Playwright 自動化截圖時環境缺少 `playwright` 套件，因此截圖測試未執行（該部分失敗）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a321027f6088332958d8090d68b60e4)