### PR TITLE
Add battle system UI and mechanics (attack/defense/magic meters, timers, resolution)

### DIFF
--- a/assets/match3.css
+++ b/assets/match3.css
@@ -18,7 +18,7 @@ select, input, button { min-height: 40px; border-radius: 10px; border: 1px solid
 button { background: #2563eb; color: white; border: 0; cursor: pointer; font-weight: 800; }
 button.secondary { background: #64748b; }
 button:disabled { opacity: .55; cursor: not-allowed; }
-.stats { display: grid; grid-template-columns: repeat(5, minmax(110px, 1fr)); gap: 12px; margin-bottom: 16px; }
+.stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(110px, 1fr)); gap: 12px; margin-bottom: 16px; }
 .stats article { padding: 14px; }
 .stats span { display: block; color: #64748b; font-size: 14px; }
 .stats strong { font-size: 26px; }
@@ -38,3 +38,23 @@ button:disabled { opacity: .55; cursor: not-allowed; }
 @keyframes spawn { from { opacity: 0; transform: translateY(var(--from-y)) scale(.75); } to { opacity: 1; transform: translateY(0) scale(1); } }
 @keyframes pulse { 50% { transform: scale(1.15); box-shadow: 0 0 0 5px #fde68a, inset 0 -7px 0 rgba(0,0,0,.12); } }
 @media (max-width: 820px) { :root { --cell-size: 36px; --gap: 4px; } .game-layout { grid-template-columns: 1fr; } .stats { grid-template-columns: repeat(2, 1fr); } .board { margin: 0 auto; } }
+.battle-panel { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 12px; margin-bottom: 16px; }
+.fighter-card { background: rgba(255,255,255,.92); border: 1px solid rgba(148,163,184,.35); border-radius: 18px; box-shadow: 0 18px 45px rgba(15,23,42,.09); padding: 16px; text-align: center; }
+.fighter-avatar { width: 86px; height: 86px; border-radius: 999px; display: grid; place-items: center; margin: 10px auto; background: linear-gradient(135deg, #60a5fa, #2563eb); color: white; font-weight: 900; }
+.fighter-card.enemy .fighter-avatar { background: linear-gradient(135deg, #fb7185, #be123c); }
+.attack-countdown { display: grid; gap: 6px; color: #64748b; font-weight: 800; }
+.bar { height: 12px; overflow: hidden; border-radius: 999px; background: #e2e8f0; box-shadow: inset 0 1px 2px rgba(15,23,42,.12); }
+.bar span { display: block; width: 0%; height: 100%; border-radius: inherit; background: linear-gradient(90deg, #38bdf8, #2563eb); transition: width 120ms linear; }
+.bar.hp span { width: 100%; background: linear-gradient(90deg, #34d399, #16a34a); }
+.game-layout { grid-template-columns: 190px max-content minmax(240px, 1fr); }
+.accumulation-panel { padding: 16px; }
+.accumulation-panel h2 { margin-top: 0; }
+.meter-row { display: grid; gap: 6px; margin-bottom: 14px; }
+.meter-row span { color: #64748b; font-weight: 800; }
+.meter-row strong { font-size: 18px; }
+#attackMeter { background: linear-gradient(90deg, #fb923c, #ef4444); }
+#defenseMeter { background: linear-gradient(90deg, #93c5fd, #2563eb); }
+#magicMeter { background: linear-gradient(90deg, #c084fc, #7c3aed); }
+.magic-button { width: 100%; min-height: 44px; margin-top: 6px; background: #7c3aed; }
+.meter-note { margin-bottom: 0; color: #64748b; font-size: 13px; line-height: 1.5; }
+@media (max-width: 820px) { .battle-panel { grid-template-columns: 1fr; } .game-layout { grid-template-columns: 1fr; } .accumulation-panel { order: -1; } }

--- a/assets/match3.ui.js
+++ b/assets/match3.ui.js
@@ -2,10 +2,11 @@
   const COLORS = ['#FF6663', '#FEB144', '#9EE09E', '#9EC1CF', '#CC99C9', '#B5EAD7', '#C7CEEA'];
   const logic = window.Match3Logic;
   const $ = id => document.getElementById(id);
-  const state = { board: [], size: 8, colorCount: 4, fallSpeed: 420, clearSpeed: 260, selected: null, busy: false, score: 0, moves: 30, target: 1200, combo: 1, startedAt: null, timerId: null, hint: [] };
+  const state = { board: [], size: 8, colorCount: 4, fallSpeed: 420, clearSpeed: 260, attackInterval: 5000, attackTimerId: null, nextAttackAt: null, pendingAttack: 0, pendingDefense: 0, pendingMagic: 0, pendingHeal: 0, playerHp: 100, enemyHp: 100, maxHp: 100, magicArmed: false, battleEnded: false, selected: null, busy: false, score: 0, moves: 30, target: 1200, combo: 1, startedAt: null, timerId: null, hint: [] };
 
   function key(pos) { return `${pos.r},${pos.c}`; }
   function sleep(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }
+  function clamp(value, min, max) { return Math.min(max, Math.max(min, value)); }
   function cellPixels() {
     const root = getComputedStyle(document.documentElement);
     return parseFloat(root.getPropertyValue('--cell-size')) + parseFloat(root.getPropertyValue('--gap'));
@@ -51,11 +52,39 @@
     $('moves').textContent = state.moves;
     $('target').textContent = state.target;
     $('combo').textContent = `x${state.combo}`;
-    $('hintButton').disabled = state.busy;
+    $('hintButton').disabled = state.busy || state.battleEnded;
     $('resetButton').disabled = state.busy;
+    renderBattleStats();
   }
 
   function setStatus(text) { $('status').textContent = text; }
+  function setBar(id, value, max = 100) {
+    $(id).style.width = `${clamp(value, 0, max) / max * 100}%`;
+  }
+
+  function renderBattleStats() {
+    const attack = clamp(state.pendingAttack, 0, 100);
+    const defense = clamp(state.pendingDefense, 0, 100);
+    const magic = clamp(state.pendingMagic, 0, 100);
+    const remaining = state.nextAttackAt ? clamp(state.nextAttackAt - Date.now(), 0, state.attackInterval) : state.attackInterval;
+    const countdownPercent = state.attackInterval ? (state.attackInterval - remaining) / state.attackInterval * 100 : 0;
+
+    $('playerHpText').textContent = `${state.playerHp} / ${state.maxHp}`;
+    $('enemyHpText').textContent = `${state.enemyHp} / ${state.maxHp}`;
+    setBar('playerHpBar', state.playerHp, state.maxHp);
+    setBar('enemyHpBar', state.enemyHp, state.maxHp);
+    setBar('playerAttackBar', countdownPercent);
+    setBar('enemyAttackBar', countdownPercent);
+    $('attackValue').textContent = `${attack} / 100`;
+    $('defenseValue').textContent = `${defense} / 100`;
+    $('magicValue').textContent = `${magic} / 100`;
+    setBar('attackMeter', attack);
+    setBar('defenseMeter', defense);
+    setBar('magicMeter', magic);
+    $('magicButton').disabled = state.battleEnded || state.magicArmed || state.pendingMagic < 50;
+    $('magicButton').textContent = state.magicArmed ? '魔法已準備：下次攻擊 x2' : '使用魔法（下次攻擊 x2）';
+  }
+
   function updateTimer() {
     if (!state.startedAt) { $('timer').textContent = '00:00'; return; }
     const sec = Math.floor((Date.now() - state.startedAt) / 1000);
@@ -65,19 +94,91 @@
     if (state.startedAt) return;
     state.startedAt = Date.now();
     state.timerId = setInterval(updateTimer, 1000);
+    startBattleTimers();
+  }
+
+  function startBattleTimers() {
+    clearInterval(state.attackTimerId);
+    state.nextAttackAt = Date.now() + state.attackInterval;
+    updateAttackTimer();
+    state.attackTimerId = setInterval(updateAttackTimer, 100);
+  }
+
+  function updateAttackTimer() {
+    if (!state.nextAttackAt) {
+      $('attackTimer').textContent = `${(state.attackInterval / 1000).toFixed(1)}s`;
+      renderBattleStats();
+      return;
+    }
+    const remaining = Math.max(0, state.nextAttackAt - Date.now());
+    $('attackTimer').textContent = `${(remaining / 1000).toFixed(1)}s`;
+    renderBattleStats();
+    if (remaining <= 0) resolvePlayerAttack();
+  }
+
+  function resolvePlayerAttack() {
+    if (state.battleEnded) return;
+
+    const attack = clamp(state.pendingAttack, 0, 100);
+    const defense = clamp(state.pendingDefense, 0, 100);
+    const heal = state.pendingHeal;
+    const multiplier = state.magicArmed ? 2 : 1;
+    const playerDamage = attack * multiplier;
+    const enemyBaseDamage = 10;
+    const enemyDamage = clamp(enemyBaseDamage - Math.floor(defense / 10), 0, enemyBaseDamage);
+
+    state.enemyHp = clamp(state.enemyHp - playerDamage, 0, state.maxHp);
+    state.playerHp = clamp(state.playerHp + heal - enemyDamage, 0, state.maxHp);
+    state.score += playerDamage * 10;
+
+    const magicText = state.magicArmed ? '，魔法加成已觸發（攻擊 x2）' : '';
+    setStatus(`回合結算：你造成 ${playerDamage} 傷害${magicText}，敵人造成 ${enemyDamage} 傷害。`);
+
+    state.pendingAttack = 0;
+    state.pendingDefense = 0;
+    state.pendingHeal = 0;
+    state.magicArmed = false;
+
+    if (state.enemyHp <= 0 || state.playerHp <= 0) {
+      endBattle(state.enemyHp <= 0 ? '恭喜勝利！敵方生命值歸 0。' : '挑戰失敗！玩家生命值歸 0。');
+      render();
+      return;
+    }
+
+    state.nextAttackAt = Date.now() + state.attackInterval;
+    render();
+  }
+
+  function endBattle(message) {
+    state.battleEnded = true;
+    clearInterval(state.attackTimerId);
+    state.attackTimerId = null;
+    state.nextAttackAt = null;
+    $('attackTimer').textContent = '停止';
+    setStatus(message);
+  }
+
+  function useMagic() {
+    if (state.battleEnded || state.magicArmed || state.pendingMagic < 50) return;
+    state.pendingMagic -= 50;
+    state.magicArmed = true;
+    setStatus('已使用魔法：下次攻擊傷害 x2。');
+    renderBattleStats();
   }
 
   function resetGame() {
     clearInterval(state.timerId);
-    Object.assign(state, { size: Number($('boardSize').value), colorCount: Number($('colorCount').value), fallSpeed: Number($('fallSpeed').value), clearSpeed: Number($('clearSpeed').value), selected: null, busy: false, score: 0, moves: 30, target: Number($('boardSize').value) * 150, combo: 1, startedAt: null, timerId: null, hint: [] });
+    clearInterval(state.attackTimerId);
+    Object.assign(state, { size: Number($('boardSize').value), colorCount: Number($('colorCount').value), fallSpeed: Number($('fallSpeed').value), clearSpeed: Number($('clearSpeed').value), attackInterval: Number($('attackInterval').value), attackTimerId: null, nextAttackAt: null, pendingAttack: 0, pendingDefense: 0, pendingMagic: 0, pendingHeal: 0, playerHp: 100, enemyHp: 100, maxHp: 100, magicArmed: false, battleEnded: false, selected: null, busy: false, score: 0, moves: 30, target: Number($('boardSize').value) * 150, combo: 1, startedAt: null, timerId: null, hint: [] });
     state.board = logic.createBoard(state.size, state.colorCount);
     updateTimer();
+    updateAttackTimer();
     setStatus('請交換相鄰方塊開始遊戲。');
     render();
   }
 
   async function handleCellClick(pos) {
-    if (state.busy || state.moves <= 0) return;
+    if (state.busy || state.moves <= 0 || state.battleEnded) return;
     state.hint = [];
     if (!state.selected) { state.selected = pos; render(); return; }
     if (!logic.areAdjacent(state.selected, pos)) { state.selected = pos; render(); return; }
@@ -111,6 +212,7 @@
     while (matches.length > 0) {
       setStatus(`消除 ${matches.length} 個方塊！`);
       state.score += matches.length * 20 * state.combo;
+      matches.forEach(({ r, c }) => accumulateBlockEffect(state.board[r][c]));
       render({ clearing: matches });
       await sleep(state.clearSpeed);
       matches.forEach(({ r, c }) => { state.board[r][c] = null; });
@@ -123,7 +225,16 @@
     }
   }
 
+  function accumulateBlockEffect(value) {
+    if (value === 0) state.pendingAttack = clamp(state.pendingAttack + 10, 0, 100);
+    else if (value === 1) state.pendingDefense = clamp(state.pendingDefense + 10, 0, 100);
+    else if (value === 2) state.pendingMagic = clamp(state.pendingMagic + 10, 0, 100);
+    else if (value === 3) state.pendingHeal = clamp(state.pendingHeal + 5, 0, 100);
+    else state.pendingAttack = clamp(state.pendingAttack + 10, 0, 100);
+  }
+
   function endTurnCheck() {
+    if (state.battleEnded) return;
     if (state.score >= state.target) { setStatus('恭喜過關！你達成目標分數了。'); return; }
     if (state.moves <= 0) { setStatus('步數用完，請重設再挑戰一次。'); return; }
     if (!logic.findAvailableMove(state.board)) {
@@ -135,7 +246,7 @@
   }
 
   function showHint() {
-    if (state.busy) return;
+    if (state.busy || state.battleEnded) return;
     const move = logic.findAvailableMove(state.board);
     state.hint = move || [];
     setStatus(move ? '已標出一組可交換的方塊。' : '目前無解，已重新排列棋盤。');
@@ -146,7 +257,13 @@
   ['colorCount', 'boardSize'].forEach(id => $(id).addEventListener('change', resetGame));
   $('fallSpeed').addEventListener('change', e => { state.fallSpeed = Number(e.target.value); render(); });
   $('clearSpeed').addEventListener('change', e => { state.clearSpeed = Number(e.target.value); render(); });
+  $('attackInterval').addEventListener('change', e => {
+    state.attackInterval = Number(e.target.value);
+    if (state.nextAttackAt) startBattleTimers();
+    else updateAttackTimer();
+  });
   $('resetButton').addEventListener('click', resetGame);
   $('hintButton').addEventListener('click', showHint);
+  $('magicButton').addEventListener('click', useMagic);
   resetGame();
 })();

--- a/index.html
+++ b/index.html
@@ -37,6 +37,9 @@
       <label>消除速度(ms)
         <input type="number" id="clearSpeed" value="260" min="80" max="1000" step="10" />
       </label>
+      <label>攻擊間隔(ms)
+        <input type="number" id="attackInterval" value="5000" min="1000" max="30000" step="100" />
+      </label>
       <button id="resetButton" type="button">重設遊戲</button>
       <button id="hintButton" type="button" class="secondary">提示</button>
     </section>
@@ -46,10 +49,52 @@
       <article><span>步數</span><strong id="moves">30</strong></article>
       <article><span>目標</span><strong id="target">1200</strong></article>
       <article><span>時間</span><strong id="timer">00:00</strong></article>
+      <article><span>攻擊倒數</span><strong id="attackTimer">5.0s</strong></article>
       <article><span>連鎖</span><strong id="combo">x1</strong></article>
     </section>
 
+    <section class="battle-panel" aria-label="戰鬥狀態">
+      <article class="fighter-card">
+        <div class="attack-countdown">
+          <span>下次攻擊</span>
+          <div class="bar"><span id="playerAttackBar"></span></div>
+        </div>
+        <div class="fighter-avatar">勇者</div>
+        <strong id="playerHpText">100 / 100</strong>
+        <div class="bar hp"><span id="playerHpBar"></span></div>
+      </article>
+      <article class="fighter-card enemy">
+        <div class="attack-countdown">
+          <span>下次攻擊</span>
+          <div class="bar"><span id="enemyAttackBar"></span></div>
+        </div>
+        <div class="fighter-avatar">魔王</div>
+        <strong id="enemyHpText">100 / 100</strong>
+        <div class="bar hp"><span id="enemyHpBar"></span></div>
+      </article>
+    </section>
+
     <section class="game-layout">
+      <aside class="panel accumulation-panel" aria-label="累積戰鬥效果">
+        <h2>累積效果</h2>
+        <div class="meter-row">
+          <span>攻擊</span>
+          <strong id="attackValue">0 / 100</strong>
+          <div class="bar"><span id="attackMeter"></span></div>
+        </div>
+        <div class="meter-row">
+          <span>防禦</span>
+          <strong id="defenseValue">0 / 100</strong>
+          <div class="bar"><span id="defenseMeter"></span></div>
+        </div>
+        <div class="meter-row">
+          <span>魔法</span>
+          <strong id="magicValue">0 / 100</strong>
+          <div class="bar"><span id="magicMeter"></span></div>
+        </div>
+        <button id="magicButton" type="button" class="magic-button">使用魔法（下次攻擊 x2）</button>
+        <p class="meter-note">魔法每 50 點可使用 1 次，最多累積 2 次。</p>
+      </aside>
       <div id="board" class="board" aria-label="三消遊戲棋盤"></div>
       <aside class="panel business-panel">
         <h2>商業化常見功能</h2>


### PR DESCRIPTION
### Motivation
- Introduce a simple RPG-style battle layer to the match-3 game so block matches can accumulate combat resources and periodically resolve attacks between player and enemy.
- Provide visible meters, countdown and controls so players can plan and trigger magic-enhanced attacks before the automated resolution.

### Description
- Extended the UI by adding an `attackInterval` input, an `attackTimer` stat, a `battle-panel` (player/enemy HP and attack countdown) and an `accumulation-panel` (attack/defense/magic meters and `magicButton`) to `index.html`.
- Added new styles in `assets/match3.css` for `.battle-panel`, `.fighter-card`, meter bars and responsive layout adjustments.
- Implemented battle state and logic in `assets/match3.ui.js` including new state fields (`pendingAttack`, `pendingDefense`, `pendingMagic`, `pendingHeal`, `playerHp`, `enemyHp`, `attackInterval`, `attackTimerId`, `nextAttackAt`, `magicArmed`, `battleEnded`), helper `clamp` and `setBar`, UI renderer `renderBattleStats`, timer management (`startBattleTimers`, `updateAttackTimer`) and resolution functions `resolvePlayerAttack`, `endBattle`, `useMagic`, and `accumulateBlockEffect` (hooked into match resolution to charge meters).
- Disabled certain interactions when the battle ends and integrated battle updates into existing flows (`startTimer`, `resetGame`, `handleCellClick`, `resolveMatches`, and `showHint`).

### Testing
- Ran linting with `npm run lint` and the codebase reported no new lint errors.
- Executed the project's automated test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a320a9e41208332b67d8109b4e98e76)