### PR TITLE
Fix board rendering regression and restore battle UI/logic

### DIFF
--- a/assets/match3.css
+++ b/assets/match3.css
@@ -38,6 +38,25 @@ button:disabled { opacity: .55; cursor: not-allowed; }
 @keyframes spawn { from { opacity: 0; transform: translateY(var(--from-y)) scale(.75); } to { opacity: 1; transform: translateY(0) scale(1); } }
 @keyframes pulse { 50% { transform: scale(1.15); box-shadow: 0 0 0 5px #fde68a, inset 0 -7px 0 rgba(0,0,0,.12); } }
 @media (max-width: 820px) { :root { --cell-size: 36px; --gap: 4px; } .game-layout { grid-template-columns: 1fr; } .stats { grid-template-columns: repeat(2, 1fr); } .board { margin: 0 auto; } }
+.battle-panel { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 12px; margin-bottom: 16px; }
+.fighter-card { background: rgba(255,255,255,.92); border: 1px solid rgba(148,163,184,.35); border-radius: 18px; box-shadow: 0 18px 45px rgba(15,23,42,.09); padding: 16px; text-align: center; }
+.fighter-avatar { width: 86px; height: 86px; border-radius: 999px; display: grid; place-items: center; margin: 10px auto; background: linear-gradient(135deg, #60a5fa, #2563eb); color: white; font-weight: 900; }
+.fighter-card.enemy .fighter-avatar { background: linear-gradient(135deg, #fb7185, #be123c); }
+.attack-countdown { display: grid; gap: 6px; color: #64748b; font-weight: 800; }
+.bar { height: 12px; overflow: hidden; border-radius: 999px; background: #e2e8f0; box-shadow: inset 0 1px 2px rgba(15,23,42,.12); }
+.bar span { display: block; width: 0%; height: 100%; border-radius: inherit; background: linear-gradient(90deg, #38bdf8, #2563eb); transition: width 120ms linear; }
+.bar.hp span { width: 100%; background: linear-gradient(90deg, #34d399, #16a34a); }
+.game-layout { grid-template-columns: 190px max-content minmax(240px, 1fr); }
+.accumulation-panel { padding: 16px; }
+.accumulation-panel h2 { margin-top: 0; }
+.meter-row { display: grid; gap: 6px; margin-bottom: 14px; }
+.meter-row span { color: #64748b; font-weight: 800; }
+.meter-row strong { font-size: 18px; }
+#attackMeter { background: linear-gradient(90deg, #fb923c, #ef4444); }
+#defenseMeter { background: linear-gradient(90deg, #93c5fd, #2563eb); }
+#magicMeter { background: linear-gradient(90deg, #c084fc, #7c3aed); }
+.magic-button { width: 100%; min-height: 44px; margin-top: 6px; background: #7c3aed; }
+.meter-note { margin-bottom: 0; color: #64748b; font-size: 13px; line-height: 1.5; }
 .stats { grid-template-columns: repeat(9, minmax(96px, 1fr)); }
 .cell { position: relative; display: grid; place-items: center; font-size: 22px; text-shadow: 0 2px 0 rgba(0,0,0,.18); }
 .cell-icon { pointer-events: none; filter: drop-shadow(0 2px 0 rgba(255,255,255,.22)); }
@@ -58,4 +77,4 @@ button:disabled { opacity: .55; cursor: not-allowed; }
 @keyframes hero-attack { 50% { transform: translateX(18px); } }
 @keyframes enemy-attack { 50% { transform: scaleX(-1) translateX(18px); } }
 @media (max-width: 980px) { .stats { grid-template-columns: repeat(3, 1fr); } }
-@media (max-width: 820px) { .stats { grid-template-columns: repeat(2, 1fr); } .effect-grid { grid-template-columns: 1fr; } }
+@media (max-width: 820px) { .battle-panel, .game-layout { grid-template-columns: 1fr; } .accumulation-panel { order: -1; } .stats { grid-template-columns: repeat(2, 1fr); } .effect-grid { grid-template-columns: 1fr; } }

--- a/assets/match3.ui.js
+++ b/assets/match3.ui.js
@@ -19,7 +19,7 @@
     hint: [], playerHp: DEFAULT_HP, enemyHp: DEFAULT_HP, maxHp: DEFAULT_HP,
     attackInterval: 5, enemyInterval: 5, nextPlayerAttackAt: null, nextEnemyAttackAt: null,
     roundStats: { attack: 0, defense: 0, spell: 0, heal: 0 },
-    lastAction: '尚未攻擊。', heroAction: false, enemyAction: false, ended: false
+    lastAction: '尚未攻擊。', heroAction: false, enemyAction: false, ended: false, magicArmed: false
   };
 
   function key(pos) { return `${pos.r},${pos.c}`; }
@@ -101,27 +101,46 @@
     $(id).style.width = `${clamp(value, 0, max) / max * 100}%`;
   }
 
-  function renderBattleStats() {
-    const attack = clamp(state.pendingAttack, 0, 100);
-    const defense = clamp(state.pendingDefense, 0, 100);
-    const magic = clamp(state.pendingMagic, 0, 100);
-    const remaining = state.nextAttackAt ? clamp(state.nextAttackAt - Date.now(), 0, state.attackInterval) : state.attackInterval;
-    const countdownPercent = state.attackInterval ? (state.attackInterval - remaining) / state.attackInterval * 100 : 0;
+  function countdownProgress(target, intervalSeconds) {
+    if (!target || state.ended) return 0;
+    const total = sleepMsFromSeconds(intervalSeconds);
+    const remaining = clamp(target - Date.now(), 0, total);
+    return total ? (total - remaining) / total * 100 : 0;
+  }
 
+  function renderBattleStats() {
+    const attack = clamp(state.roundStats.attack * 10, 0, 100);
+    const defense = clamp(state.roundStats.defense * 10, 0, 100);
+    const magic = clamp(state.roundStats.spell * 10, 0, 100);
+
+    $('attackTimer').textContent = formatCountdown(state.nextPlayerAttackAt) === '--' ? `${state.attackInterval}.0s` : formatCountdown(state.nextPlayerAttackAt);
     $('playerHpText').textContent = `${state.playerHp} / ${state.maxHp}`;
     $('enemyHpText').textContent = `${state.enemyHp} / ${state.maxHp}`;
     setBar('playerHpBar', state.playerHp, state.maxHp);
     setBar('enemyHpBar', state.enemyHp, state.maxHp);
-    setBar('playerAttackBar', countdownPercent);
-    setBar('enemyAttackBar', countdownPercent);
+    setBar('playerAttackBar', countdownProgress(state.nextPlayerAttackAt, state.attackInterval));
+    setBar('enemyAttackBar', countdownProgress(state.nextEnemyAttackAt, state.enemyInterval));
     $('attackValue').textContent = `${attack} / 100`;
     $('defenseValue').textContent = `${defense} / 100`;
     $('magicValue').textContent = `${magic} / 100`;
     setBar('attackMeter', attack);
     setBar('defenseMeter', defense);
     setBar('magicMeter', magic);
-    $('magicButton').disabled = state.battleEnded || state.magicArmed || state.pendingMagic < 50;
-    $('magicButton').textContent = state.magicArmed ? '魔法已準備：下次攻擊 x2' : '使用魔法（下次攻擊 x2）';
+    $('magicButton').disabled = state.ended || state.magicArmed || state.roundStats.spell < 5;
+    $('magicButton').textContent = state.magicArmed ? '魔法已準備：下次攻擊 x2' : '使用魔法（消耗 5 法術，下次攻擊 x2）';
+  }
+
+  function updateAttackTimer() {
+    renderBattleStats();
+  }
+
+  function useMagic() {
+    if (state.ended || state.magicArmed || state.roundStats.spell < 5) return;
+    state.roundStats.spell -= 5;
+    state.magicArmed = true;
+    state.lastAction = '已使用魔法：下次我方攻擊傷害 x2。';
+    setStatus('已使用魔法：下次我方攻擊傷害 x2。');
+    render();
   }
 
   function updateTimer() {
@@ -147,7 +166,7 @@
 
   function resetGame() {
     stopTimers();
-    Object.assign(state, { size: Number($('boardSize').value), colorCount: Number($('colorCount').value), fallSpeed: Number($('fallSpeed').value), clearSpeed: Number($('clearSpeed').value), attackInterval: Number($('attackInterval').value), enemyInterval: Number($('enemyInterval').value), selected: null, busy: false, score: 0, moves: 30, target: Number($('boardSize').value) * 150, combo: 1, startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null, hint: [], playerHp: DEFAULT_HP, enemyHp: DEFAULT_HP, maxHp: DEFAULT_HP, nextPlayerAttackAt: null, nextEnemyAttackAt: null, lastAction: '交換方塊後，雙方攻擊計時器會開始。', heroAction: false, enemyAction: false, ended: false });
+    Object.assign(state, { size: Number($('boardSize').value), colorCount: Number($('colorCount').value), fallSpeed: Number($('fallSpeed').value), clearSpeed: Number($('clearSpeed').value), attackInterval: Number($('attackInterval').value), enemyInterval: Number($('enemyInterval').value), selected: null, busy: false, score: 0, moves: 30, target: Number($('boardSize').value) * 150, combo: 1, startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null, hint: [], playerHp: DEFAULT_HP, enemyHp: DEFAULT_HP, maxHp: DEFAULT_HP, nextPlayerAttackAt: null, nextEnemyAttackAt: null, lastAction: '交換方塊後，雙方攻擊計時器會開始。', heroAction: false, enemyAction: false, ended: false, magicArmed: false });
     resetRoundStats();
     state.board = logic.createBoard(state.size, state.colorCount);
     updateTimer();
@@ -217,14 +236,16 @@
 
   function playerAttack() {
     if (state.ended) return;
-    const damage = state.roundStats.attack + (state.roundStats.spell * 2);
+    const baseDamage = state.roundStats.attack + (state.roundStats.spell * 2);
+    const damage = state.magicArmed ? baseDamage * 2 : baseDamage;
     const heal = state.roundStats.heal;
     state.enemyHp = clamp(state.enemyHp - damage, 0, state.maxHp);
     state.playerHp = clamp(state.playerHp + heal, 0, state.maxHp);
-    state.lastAction = `我方攻擊造成 ${damage} 傷害，回血 ${heal}。防禦會保留到敵方攻擊結算。`;
+    state.lastAction = `我方攻擊造成 ${damage} 傷害${state.magicArmed ? '（魔法 x2）' : ''}，回血 ${heal}。防禦會保留到敵方攻擊結算。`;
     state.roundStats.attack = 0;
     state.roundStats.spell = 0;
     state.roundStats.heal = 0;
+    state.magicArmed = false;
     state.nextPlayerAttackAt = Date.now() + sleepMsFromSeconds(state.attackInterval);
     flashActor('hero');
     checkBattleEnd();


### PR DESCRIPTION
### Motivation
- A recent change introduced a regression that prevented the board from rendering (cells missing) by breaking the battle/timer initialization flow and referencing stale/removed fields in the battle UI code.
- The battle/meter UI was partially added in HTML but lacked matching CSS and handlers, making the layout appear broken even when elements existed.
- Magic handling and attack-timing logic needed to be consistent with the current `roundStats` model so rendering and battle resolution do not throw or stop mid-initialize.

### Description
- Rewrote UI logic to use the current `roundStats` fields for meters and removed reliance on nonexistent `pending*` fields; updated rendering to always call `renderBattleStats()` so battle panels stay in sync. (assets/match3.ui.js)
- Restored attack/timer update hooks (`updateAttackTimer()` call during reset/start) and reintroduced `magicArmed` handling plus `useMagic()` so magic x2 applies correctly and state resets after resolution. (assets/match3.ui.js)
- Added `countdownProgress` and `setBar` helpers and wired attack countdown bars to display progress based on configured intervals. (assets/match3.ui.js)
- Restored missing battle-panel and accumulation-panel styles and responsive layout rules so side panels and board render correctly together. (assets/match3.css)

### Testing
- Ran `node --check assets/match3.ui.js` and it succeeded. 
- Ran `node --check assets/match3.logic.js` and it succeeded.
- Executed a headless Node DOM smoke test that initializes the scripts and asserted the board contains 64 cells, which passed.
- Ran `git diff --check` to validate whitespace/patch issues and it returned clean results.
- Attempted a quick `python3 -m http.server` smoke check to fetch the index but the HTTP connection to the ephemeral server failed in this environment, so the HTTP fetch test did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32166464988332ba3093579d3d3fe4)