### PR TITLE
Fix match clearing and enemy sprite flicker

### DIFF
--- a/assets/match3.css
+++ b/assets/match3.css
@@ -66,7 +66,7 @@ button:disabled { opacity: .55; cursor: not-allowed; }
 .pixel-sprite { position: relative; width: 54px; height: 72px; image-rendering: pixelated; animation: idle-bob 900ms steps(2, end) infinite; }
 .pixel-sprite::before { content: ''; position: absolute; left: 17px; top: 4px; width: 20px; height: 20px; background: #f8c38a; box-shadow: 0 20px 0 #2563eb, -10px 28px 0 #1d4ed8, 10px 28px 0 #1d4ed8, -8px 48px 0 #334155, 8px 48px 0 #334155, 0 -6px 0 #7c2d12; }
 .pixel-sprite::after { content: ''; position: absolute; left: 39px; top: 30px; width: 8px; height: 28px; background: #f59e0b; transform-origin: top center; box-shadow: 0 22px 0 #92400e; }
-.enemy-sprite { transform: scaleX(-1); filter: hue-rotate(145deg) saturate(1.2); }
+.enemy-sprite { transform: scaleX(-1); filter: hue-rotate(145deg) saturate(1.2); animation-name: enemy-idle-bob; }
 .hero-sprite.attacking { animation: hero-attack 520ms steps(3, end); }
 .enemy-sprite.attacking { animation: enemy-attack 520ms steps(3, end); }
 .hero-sprite.attacking::after, .enemy-sprite.attacking::after { transform: rotate(-55deg); }
@@ -74,7 +74,8 @@ button:disabled { opacity: .55; cursor: not-allowed; }
 .effect-grid span, .battle-log { border-radius: 12px; background: #f8fafc; border: 1px solid #e2e8f0; padding: 10px; font-weight: 700; }
 .battle-log { color: #7c2d12; background: #fff7ed; }
 @keyframes idle-bob { 50% { transform: translateY(-3px); } }
+@keyframes enemy-idle-bob { 0%, 100% { transform: scaleX(-1) translateY(0); } 50% { transform: scaleX(-1) translateY(-3px); } }
 @keyframes hero-attack { 50% { transform: translateX(18px); } }
-@keyframes enemy-attack { 50% { transform: scaleX(-1) translateX(18px); } }
+@keyframes enemy-attack { 0%, 100% { transform: scaleX(-1) translateX(0); } 50% { transform: scaleX(-1) translateX(18px); } }
 @media (max-width: 980px) { .stats { grid-template-columns: repeat(3, 1fr); } }
 @media (max-width: 820px) { .battle-panel, .game-layout { grid-template-columns: 1fr; } .accumulation-panel { order: -1; } .stats { grid-template-columns: repeat(2, 1fr); } .effect-grid { grid-template-columns: 1fr; } }

--- a/assets/match3.ui.js
+++ b/assets/match3.ui.js
@@ -164,6 +164,12 @@
 
   function resetRoundStats() { state.roundStats = { attack: 0, defense: 0, spell: 0, heal: 0 }; }
 
+  function accumulateBlockEffect(value) {
+    if (value === null) return;
+    const type = blockType(value);
+    state.roundStats[type.stat] += 1;
+  }
+
   function resetGame() {
     stopTimers();
     Object.assign(state, { size: Number($('boardSize').value), colorCount: Number($('colorCount').value), fallSpeed: Number($('fallSpeed').value), clearSpeed: Number($('clearSpeed').value), attackInterval: Number($('attackInterval').value), enemyInterval: Number($('enemyInterval').value), selected: null, busy: false, score: 0, moves: 30, target: Number($('boardSize').value) * 150, combo: 1, startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null, hint: [], playerHp: DEFAULT_HP, enemyHp: DEFAULT_HP, maxHp: DEFAULT_HP, nextPlayerAttackAt: null, nextEnemyAttackAt: null, lastAction: '交換方塊後，雙方攻擊計時器會開始。', heroAction: false, enemyAction: false, ended: false, magicArmed: false });
@@ -209,10 +215,6 @@
     let matches = logic.findMatches(state.board);
     while (matches.length > 0) {
       setStatus(`消除 ${matches.length} 個方塊，效果已累積到本輪計時器。`);
-      matches.forEach(({ r, c }) => {
-        const type = blockType(state.board[r][c]);
-        state.roundStats[type.stat] += 1;
-      });
       state.score += matches.length * 20 * state.combo;
       matches.forEach(({ r, c }) => accumulateBlockEffect(state.board[r][c]));
       render({ clearing: matches });


### PR DESCRIPTION
### Motivation
- Players reported that a single swap would not trigger normal clears and the board would get stuck because match effects were not being accumulated correctly.
- The enemy pixel sprite was visually flickering due to animation transforms that flipped the sprite during idle/attack animations.

### Description
- Added `accumulateBlockEffect(value)` to `assets/match3.ui.js` to centralize per-block stat accumulation and prevent missing-function errors during match resolution.
- Removed the duplicated inline stat accumulation inside the match loop and now call `accumulateBlockEffect` for each cleared block during `resolveMatches`.
- Updated `assets/match3.css` to introduce `@keyframes enemy-idle-bob` and adjusted `@keyframes enemy-attack` while keeping the `scaleX(-1)` transform so the enemy sprite no longer flips/flickers between animations.

### Testing
- Ran `node --check assets/match3.logic.js` which succeeded.
- Ran `node --check assets/match3.ui.js` which succeeded.
- Ran `git diff --check` to verify no whitespace/patch issues, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3230259c7c8332a6d9584446f8eacb)