### PR TITLE
Fix modular match3 battle settings

### DIFF
--- a/assets/match3.logic.js
+++ b/assets/match3.logic.js
@@ -1,0 +1,111 @@
+(function (global) {
+  const Match3Logic = {
+    createBoard(size, colorCount) {
+      let board;
+      do {
+        board = Array.from({ length: size }, () => Array.from({ length: size }, () => Math.floor(Math.random() * colorCount)));
+      } while (this.findMatches(board).length > 0 || !this.findAvailableMove(board));
+      return board;
+    },
+
+    cloneBoard(board) {
+      return board.map(row => row.slice());
+    },
+
+    swap(board, a, b) {
+      const next = this.cloneBoard(board);
+      [next[a.r][a.c], next[b.r][b.c]] = [next[b.r][b.c], next[a.r][a.c]];
+      return next;
+    },
+
+    areAdjacent(a, b) {
+      return Math.abs(a.r - b.r) + Math.abs(a.c - b.c) === 1;
+    },
+
+    findMatches(board) {
+      const matches = new Map();
+      const size = board.length;
+      const add = (r, c) => matches.set(`${r},${c}`, { r, c });
+
+      for (let r = 0; r < size; r++) {
+        let start = 0;
+        for (let c = 1; c <= size; c++) {
+          const current = c < size ? board[r][c] : Symbol('end');
+          if (board[r][start] !== null && current === board[r][start]) continue;
+          if (c - start >= 3 && board[r][start] !== null) {
+            for (let x = start; x < c; x++) add(r, x);
+          }
+          start = c;
+        }
+      }
+
+      for (let c = 0; c < size; c++) {
+        let start = 0;
+        for (let r = 1; r <= size; r++) {
+          const current = r < size ? board[r][c] : Symbol('end');
+          if (board[start][c] !== null && current === board[start][c]) continue;
+          if (r - start >= 3 && board[start][c] !== null) {
+            for (let y = start; y < r; y++) add(y, c);
+          }
+          start = r;
+        }
+      }
+
+      return Array.from(matches.values());
+    },
+
+    collapse(board, colorCount) {
+      const size = board.length;
+      const next = Array.from({ length: size }, () => Array(size).fill(null));
+      const fallMoves = [];
+      const spawnMoves = [];
+
+      for (let c = 0; c < size; c++) {
+        let target = size - 1;
+        for (let r = size - 1; r >= 0; r--) {
+          if (board[r][c] !== null) {
+            next[target][c] = board[r][c];
+            if (target !== r) fallMoves.push({ from: { r, c }, to: { r: target, c }, distance: target - r });
+            target--;
+          }
+        }
+        for (let r = target; r >= 0; r--) {
+          next[r][c] = Math.floor(Math.random() * colorCount);
+          spawnMoves.push({ to: { r, c }, distance: r + 1 });
+        }
+      }
+
+      return { board: next, fallMoves, spawnMoves };
+    },
+
+    findAvailableMove(board) {
+      const size = board.length;
+      for (let r = 0; r < size; r++) {
+        for (let c = 0; c < size; c++) {
+          for (const next of [{ r: r + 1, c }, { r, c: c + 1 }]) {
+            if (next.r >= size || next.c >= size) continue;
+            const swapped = this.swap(board, { r, c }, next);
+            if (this.findMatches(swapped).length > 0) return [{ r, c }, next];
+          }
+        }
+      }
+      return null;
+    },
+
+    shuffleBoard(board) {
+      const size = board.length;
+      const values = board.flat();
+      let next;
+      do {
+        for (let i = values.length - 1; i > 0; i--) {
+          const j = Math.floor(Math.random() * (i + 1));
+          [values[i], values[j]] = [values[j], values[i]];
+        }
+        next = Array.from({ length: size }, (_, r) => values.slice(r * size, (r + 1) * size));
+      } while (this.findMatches(next).length > 0 || !this.findAvailableMove(next));
+      return next;
+    }
+  };
+
+  global.Match3Logic = Match3Logic;
+})(window);

--- a/assets/match3/main.js
+++ b/assets/match3/main.js
@@ -1,12 +1,13 @@
 (function () {
   const logic = window.Match3Logic;
   const { blockType } = window.Match3Config;
-  const { DEFAULT_HP, ENEMY_ATTACK, createState, resetRoundStats } = window.Match3State;
+  const { createState, resetRoundStats } = window.Match3State;
   const { $, clamp, setStatus } = window.Match3Dom;
   const state = createState();
 
   function sleep(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }
   function sleepMsFromSeconds(seconds) { return Math.max(1, Number(seconds)) * 1000; }
+  function formatNumber(value) { return Number.isInteger(value) ? String(value) : value.toFixed(1); }
   function formatCountdown(target) {
     if (!target || state.ended) return '--';
     return `${Math.max(0, Math.ceil((target - Date.now()) / 1000))}s`;
@@ -59,7 +60,9 @@
 
   function resetGame() {
     stopTimers();
-    Object.assign(state, { size: Number($('boardSize').value), colorCount: Number($('colorCount').value), fallSpeed: Number($('fallSpeed').value), clearSpeed: Number($('clearSpeed').value), attackInterval: Number($('attackInterval').value), enemyInterval: Number($('enemyInterval').value), selected: null, busy: false, score: 0, moves: 30, target: Number($('boardSize').value) * 150, combo: 1, startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null, hint: [], playerHp: DEFAULT_HP, enemyHp: DEFAULT_HP, maxHp: DEFAULT_HP, nextPlayerAttackAt: null, nextEnemyAttackAt: null, lastAction: '交換方塊後，雙方攻擊計時器會開始。', heroAction: false, enemyAction: false, ended: false, magicArmed: false });
+    const playerMaxHp = Math.max(1, Number($('playerMaxHpInput').value));
+    const enemyMaxHp = Math.max(1, Number($('enemyMaxHpInput').value));
+    Object.assign(state, { size: Number($('boardSize').value), colorCount: Number($('colorCount').value), fallSpeed: Number($('fallSpeed').value), clearSpeed: Number($('clearSpeed').value), attackInterval: Number($('attackInterval').value), enemyInterval: Number($('enemyInterval').value), attackMultiplier: Math.max(0, Number($('attackMultiplier').value)), defenseMultiplier: Math.max(0, Number($('defenseMultiplier').value)), enemyAttackPower: Math.max(0, Number($('enemyAttackPower').value)), selected: null, busy: false, score: 0, moves: 30, target: Number($('boardSize').value) * 150, combo: 1, startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null, hint: [], playerHp: playerMaxHp, enemyHp: enemyMaxHp, playerMaxHp, enemyMaxHp, nextPlayerAttackAt: null, nextEnemyAttackAt: null, lastAction: '交換方塊後，雙方攻擊計時器會開始。', heroAction: false, enemyAction: false, ended: false, magicArmed: false });
     resetRoundStats(state);
     state.board = logic.createBoard(state.size, state.colorCount);
     updateTimer();
@@ -111,7 +114,11 @@
       state.score += matches.length * 20 * state.combo;
       render({ clearing: matches });
       await sleep(state.clearSpeed);
-      matches.forEach(({ r, c }) => { state.board[r][c] = null; });
+      matches.forEach(({ r, c }) => {
+        const type = blockType(state.board[r][c]);
+        state.roundStats[type.stat] += 1;
+        state.board[r][c] = null;
+      });
       const collapsed = logic.collapse(state.board, state.colorCount);
       state.board = collapsed.board;
       render({ fallMoves: collapsed.fallMoves, spawnMoves: collapsed.spawnMoves });
@@ -146,11 +153,11 @@
   render = renderer.render;
   renderBattleStats = renderer.renderBattleStats;
 
-  const battle = window.Match3Battle.createBattleSystem({ state, render, setStatus, clamp, sleepMsFromSeconds, stopTimers, resetRoundStats, enemyAttackPower: ENEMY_ATTACK });
+  const battle = window.Match3Battle.createBattleSystem({ state, render, setStatus, clamp, sleepMsFromSeconds, stopTimers, resetRoundStats, formatNumber });
   playerAttack = battle.playerAttack;
   enemyAttack = battle.enemyAttack;
 
-  ['colorCount', 'boardSize'].forEach(id => $(id).addEventListener('change', resetGame));
+  ['colorCount', 'boardSize', 'playerMaxHpInput', 'enemyMaxHpInput', 'attackMultiplier', 'defenseMultiplier', 'enemyAttackPower'].forEach(id => $(id).addEventListener('change', resetGame));
   $('fallSpeed').addEventListener('change', e => { state.fallSpeed = Number(e.target.value); render(); });
   $('clearSpeed').addEventListener('change', e => { state.clearSpeed = Number(e.target.value); render(); });
   $('attackInterval').addEventListener('change', resetGame);

--- a/assets/match3/state/game-state.js
+++ b/assets/match3/state/game-state.js
@@ -11,7 +11,8 @@
       board: [], size: 8, colorCount: 4, fallSpeed: 420, clearSpeed: 260,
       selected: null, busy: false, score: 0, moves: 30, target: 1200, combo: 1,
       startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null,
-      hint: [], playerHp: DEFAULT_HP, enemyHp: DEFAULT_HP, maxHp: DEFAULT_HP,
+      hint: [], playerHp: DEFAULT_HP, enemyHp: DEFAULT_HP, playerMaxHp: DEFAULT_HP, enemyMaxHp: DEFAULT_HP,
+      attackMultiplier: 1, defenseMultiplier: 1, enemyAttackPower: ENEMY_ATTACK,
       attackInterval: 5, enemyInterval: 5, nextPlayerAttackAt: null, nextEnemyAttackAt: null,
       roundStats: createRoundStats(),
       lastAction: '尚未攻擊。', heroAction: false, enemyAction: false, ended: false, magicArmed: false

--- a/assets/match3/systems/battle.js
+++ b/assets/match3/systems/battle.js
@@ -1,5 +1,5 @@
 (function (global) {
-  function createBattleSystem({ state, render, setStatus, clamp, sleepMsFromSeconds, stopTimers, resetRoundStats, enemyAttackPower }) {
+  function createBattleSystem({ state, render, setStatus, clamp, sleepMsFromSeconds, stopTimers, resetRoundStats, formatNumber }) {
     function flashActor(actor) {
       if (actor === 'hero') state.heroAction = true;
       else state.enemyAction = true;
@@ -15,12 +15,12 @@
 
     function playerAttack() {
       if (state.ended) return;
-      const baseDamage = state.roundStats.attack + (state.roundStats.spell * 2);
+      const baseDamage = (state.roundStats.attack * state.attackMultiplier) + (state.roundStats.spell * 2);
       const damage = state.magicArmed ? baseDamage * 2 : baseDamage;
       const heal = state.roundStats.heal;
-      state.enemyHp = clamp(state.enemyHp - damage, 0, state.maxHp);
-      state.playerHp = clamp(state.playerHp + heal, 0, state.maxHp);
-      state.lastAction = `我方攻擊造成 ${damage} 傷害${state.magicArmed ? '（魔法 x2）' : ''}，回血 ${heal}。防禦會保留到敵方攻擊結算。`;
+      state.enemyHp = clamp(state.enemyHp - damage, 0, state.enemyMaxHp);
+      state.playerHp = clamp(state.playerHp + heal, 0, state.playerMaxHp);
+      state.lastAction = `我方攻擊造成 ${formatNumber(damage)} 傷害${state.magicArmed ? '（魔法 x2）' : ''}，回血 ${formatNumber(heal)}。防禦會保留到敵方攻擊結算。`;
       state.roundStats.attack = 0;
       state.roundStats.spell = 0;
       state.roundStats.heal = 0;
@@ -32,10 +32,10 @@
 
     function enemyAttack() {
       if (state.ended) return;
-      const blocked = Math.min(enemyAttackPower, state.roundStats.defense);
-      const damage = enemyAttackPower - blocked;
-      state.playerHp = clamp(state.playerHp - damage, 0, state.maxHp);
-      state.lastAction = `敵方攻擊 ${enemyAttackPower}，防禦方塊抵擋 ${blocked}，我方受到 ${damage} 傷害。`;
+      const blocked = Math.min(state.enemyAttackPower, state.roundStats.defense * state.defenseMultiplier);
+      const damage = state.enemyAttackPower - blocked;
+      state.playerHp = clamp(state.playerHp - damage, 0, state.playerMaxHp);
+      state.lastAction = `敵方攻擊 ${formatNumber(state.enemyAttackPower)}，防禦方塊抵擋 ${formatNumber(blocked)}，我方受到 ${formatNumber(damage)} 傷害。`;
       resetRoundStats(state);
       state.nextEnemyAttackAt = Date.now() + sleepMsFromSeconds(state.enemyInterval);
       flashActor('enemy');

--- a/assets/match3/ui/render.js
+++ b/assets/match3/ui/render.js
@@ -5,6 +5,7 @@
   function clamp(value, min, max) { return Math.max(min, Math.min(max, value)); }
   function setStatus(text) { $('status').textContent = text; }
   function setBar(id, value, max = 100) { $(id).style.width = `${clamp(value, 0, max) / max * 100}%`; }
+  function formatNumber(value) { return Number.isInteger(value) ? String(value) : value.toFixed(1); }
   function cellPixels() {
     const root = getComputedStyle(document.documentElement);
     return parseFloat(root.getPropertyValue('--cell-size')) + parseFloat(root.getPropertyValue('--gap'));
@@ -12,22 +13,24 @@
 
   function createRenderer({ state, blockType, formatCountdown, countdownProgress, onCellClick }) {
     function renderBattleStats() {
-      const attack = clamp(state.roundStats.attack * 10, 0, 100);
-      const defense = clamp(state.roundStats.defense * 10, 0, 100);
-      const magic = clamp(state.roundStats.spell * 10, 0, 100);
+      const attack = state.roundStats.attack * state.attackMultiplier;
+      const defense = state.roundStats.defense * state.defenseMultiplier;
+      const magic = state.roundStats.spell * 10;
+      const attackMeterMax = Math.max(100, state.enemyMaxHp);
+      const defenseMeterMax = Math.max(100, state.enemyAttackPower);
 
       $('attackTimer').textContent = formatCountdown(state.nextPlayerAttackAt) === '--' ? `${state.attackInterval}.0s` : formatCountdown(state.nextPlayerAttackAt);
-      $('playerHpText').textContent = `${state.playerHp} / ${state.maxHp}`;
-      $('enemyHpText').textContent = `${state.enemyHp} / ${state.maxHp}`;
-      setBar('playerHpBar', state.playerHp, state.maxHp);
-      setBar('enemyHpBar', state.enemyHp, state.maxHp);
+      $('playerHpText').textContent = `${formatNumber(state.playerHp)} / ${formatNumber(state.playerMaxHp)}`;
+      $('enemyHpText').textContent = `${formatNumber(state.enemyHp)} / ${formatNumber(state.enemyMaxHp)}`;
+      setBar('playerHpBar', state.playerHp, state.playerMaxHp);
+      setBar('enemyHpBar', state.enemyHp, state.enemyMaxHp);
       setBar('playerAttackBar', countdownProgress(state.nextPlayerAttackAt, state.attackInterval));
       setBar('enemyAttackBar', countdownProgress(state.nextEnemyAttackAt, state.enemyInterval));
-      $('attackValue').textContent = `${attack} / 100`;
-      $('defenseValue').textContent = `${defense} / 100`;
-      $('magicValue').textContent = `${magic} / 100`;
-      setBar('attackMeter', attack);
-      setBar('defenseMeter', defense);
+      $('attackValue').textContent = `${formatNumber(attack)} / ${formatNumber(attackMeterMax)}`;
+      $('defenseValue').textContent = `${formatNumber(defense)} / ${formatNumber(defenseMeterMax)}`;
+      $('magicValue').textContent = `${formatNumber(clamp(magic, 0, 100))} / 100`;
+      setBar('attackMeter', attack, attackMeterMax);
+      setBar('defenseMeter', defense, defenseMeterMax);
       setBar('magicMeter', magic);
       $('magicButton').disabled = state.ended || state.magicArmed || state.roundStats.spell < 5;
       $('magicButton').textContent = state.magicArmed ? '魔法已準備：下次攻擊 x2' : '使用魔法（消耗 5 法術，下次攻擊 x2）';
@@ -77,8 +80,8 @@
       $('moves').textContent = state.moves;
       $('target').textContent = state.target;
       $('combo').textContent = `x${state.combo}`;
-      $('playerHp').textContent = `${state.playerHp}/${state.maxHp}`;
-      $('enemyHp').textContent = `${state.enemyHp}/${state.maxHp}`;
+      $('playerHp').textContent = `${formatNumber(state.playerHp)}/${formatNumber(state.playerMaxHp)}`;
+      $('enemyHp').textContent = `${formatNumber(state.enemyHp)}/${formatNumber(state.enemyMaxHp)}`;
       $('playerAttackCountdown').textContent = formatCountdown(state.nextPlayerAttackAt);
       $('enemyAttackCountdown').textContent = formatCountdown(state.nextEnemyAttackAt);
       $('roundAttack').textContent = state.roundStats.attack;


### PR DESCRIPTION
### Motivation
- Modular refactor split the UI, state and battle logic and left several battle-related state fields and UI bindings missing, causing unit tests to fail due to mismatched HP/meter values and missing accumulation of cleared-block stats.
- Restore consistent state and rendering so battle calculations and the existing unit test harness observe the same values as the original monolithic code.

### Description
- Restore battle-related state fields in `assets/match3/state/game-state.js` by adding `playerMaxHp`, `enemyMaxHp`, `attackMultiplier`, `defenseMultiplier`, and `enemyAttackPower` to the initial state.
- Update `assets/match3/main.js` `resetGame()` to read the new input controls (`playerMaxHpInput`, `enemyMaxHpInput`, `attackMultiplier`, `defenseMultiplier`, `enemyAttackPower`) and initialize `playerHp`/`enemyHp` and multipliers accordingly, and rewire those inputs to trigger `resetGame()` on change.
- Re-enable accumulation of block effects when matches are cleared so `state.roundStats` is incremented for attack/defense/spell/heal during `resolveMatches()` in `assets/match3/main.js`.
- Update battle calculations and formatting in `assets/match3/systems/battle.js` and UI rendering in `assets/match3/ui/render.js` to use the separate max HP, multipliers, and enemy attack power and to format values/meter maxima correctly.

### Testing
- Ran the test suite with `npm test` which executes the node test harness, and the TAP output shows the `match3 basic UI tests passed` test succeeded.
- The modified test run reports 1 test, 1 pass, 0 failures (TAP output from `node --test`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a323c3584f08332958216010b5c7c63)