### PR TITLE
加入特殊消除方塊與點選啟動行為

### DIFF
--- a/assets/match3.css
+++ b/assets/match3.css
@@ -79,3 +79,10 @@ button:disabled { opacity: .55; cursor: not-allowed; }
 @keyframes enemy-attack { 0%, 100% { transform: scaleX(-1) translateX(0); } 50% { transform: scaleX(-1) translateX(18px); } }
 @media (max-width: 980px) { .stats { grid-template-columns: repeat(3, 1fr); } }
 @media (max-width: 820px) { .battle-panel, .game-layout { grid-template-columns: 1fr; } .accumulation-panel { order: -1; } .stats { grid-template-columns: repeat(2, 1fr); } .effect-grid { grid-template-columns: 1fr; } }
+
+.cell.special { border-color: #fff7ed; box-shadow: inset 0 -7px 0 rgba(0,0,0,.12), 0 0 0 3px rgba(250,204,21,.8), 0 10px 18px rgba(15,23,42,.22); overflow: hidden; }
+.cell.special::before { content: ''; position: absolute; inset: -35%; background: conic-gradient(from 0deg, transparent, rgba(255,255,255,.72), transparent 32%); animation: special-spin 1.8s linear infinite; }
+.cell.special-color { background: conic-gradient(#FF6663, #60A5FA, #A78BFA, #34D399, #FEB144, #FF6663) !important; }
+.special-icon { position: absolute; right: 2px; bottom: 0; display: grid; place-items: center; width: 18px; height: 18px; border-radius: 999px; background: rgba(17,24,39,.82); color: white; font-size: 12px; line-height: 1; z-index: 1; }
+.cell-icon { position: relative; z-index: 1; }
+@keyframes special-spin { to { transform: rotate(360deg); } }

--- a/assets/match3/core/logic.js
+++ b/assets/match3/core/logic.js
@@ -1,15 +1,55 @@
 (function (global) {
+  const SPECIAL_TYPES = {
+    LINE_ROW: 'line-row',
+    LINE_COLUMN: 'line-column',
+    BOMB: 'bomb',
+    COLOR: 'color'
+  };
+
+  function isSpecialBlock(value) {
+    return value !== null && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, 'special');
+  }
+
+  function colorOf(value) {
+    return isSpecialBlock(value) ? value.color : value;
+  }
+
+  function sameColor(a, b) {
+    return a !== null && b !== null && colorOf(a) === colorOf(b);
+  }
+
+  function createNormalBlock(color) {
+    return color;
+  }
+
+  function createSpecialBlock(color, special) {
+    return { color, special };
+  }
+
   const Match3Logic = {
+    SPECIAL_TYPES,
+    isSpecialBlock,
+    colorOf,
+    createSpecialBlock,
+
+    createRandomBlock(colorCount) {
+      return createNormalBlock(Math.floor(Math.random() * colorCount));
+    },
+
     createBoard(size, colorCount) {
       let board;
       do {
-        board = Array.from({ length: size }, () => Array.from({ length: size }, () => Math.floor(Math.random() * colorCount)));
+        board = Array.from({ length: size }, () => Array.from({ length: size }, () => this.createRandomBlock(colorCount)));
       } while (this.findMatches(board).length > 0 || !this.findAvailableMove(board));
       return board;
     },
 
+    cloneBlock(value) {
+      return isSpecialBlock(value) ? { ...value } : value;
+    },
+
     cloneBoard(board) {
-      return board.map(row => row.slice());
+      return board.map(row => row.map(value => this.cloneBlock(value)));
     },
 
     swap(board, a, b) {
@@ -22,18 +62,17 @@
       return Math.abs(a.r - b.r) + Math.abs(a.c - b.c) === 1;
     },
 
-    findMatches(board) {
-      const matches = new Map();
+    findMatchGroups(board) {
+      const groups = [];
       const size = board.length;
-      const add = (r, c) => matches.set(`${r},${c}`, { r, c });
 
       for (let r = 0; r < size; r++) {
         let start = 0;
         for (let c = 1; c <= size; c++) {
-          const current = c < size ? board[r][c] : Symbol('end');
-          if (board[r][start] !== null && current === board[r][start]) continue;
+          const current = c < size ? board[r][c] : null;
+          if (board[r][start] !== null && sameColor(current, board[r][start])) continue;
           if (c - start >= 3 && board[r][start] !== null) {
-            for (let x = start; x < c; x++) add(r, x);
+            groups.push({ orientation: 'row', color: colorOf(board[r][start]), cells: Array.from({ length: c - start }, (_, index) => ({ r, c: start + index })) });
           }
           start = c;
         }
@@ -42,16 +81,28 @@
       for (let c = 0; c < size; c++) {
         let start = 0;
         for (let r = 1; r <= size; r++) {
-          const current = r < size ? board[r][c] : Symbol('end');
-          if (board[start][c] !== null && current === board[start][c]) continue;
+          const current = r < size ? board[r][c] : null;
+          if (board[start][c] !== null && sameColor(current, board[start][c])) continue;
           if (r - start >= 3 && board[start][c] !== null) {
-            for (let y = start; y < r; y++) add(y, c);
+            groups.push({ orientation: 'column', color: colorOf(board[start][c]), cells: Array.from({ length: r - start }, (_, index) => ({ r: start + index, c })) });
           }
           start = r;
         }
       }
 
+      return groups;
+    },
+
+    findMatches(board) {
+      const matches = new Map();
+      this.findMatchGroups(board).forEach(group => group.cells.forEach(({ r, c }) => matches.set(`${r},${c}`, { r, c })));
       return Array.from(matches.values());
+    },
+
+    getSpecialForGroup(group) {
+      if (group.cells.length >= 5) return SPECIAL_TYPES.COLOR;
+      if (group.cells.length === 4) return group.orientation === 'row' ? SPECIAL_TYPES.LINE_ROW : SPECIAL_TYPES.LINE_COLUMN;
+      return null;
     },
 
     collapse(board, colorCount) {
@@ -64,13 +115,13 @@
         let target = size - 1;
         for (let r = size - 1; r >= 0; r--) {
           if (board[r][c] !== null) {
-            next[target][c] = board[r][c];
+            next[target][c] = this.cloneBlock(board[r][c]);
             if (target !== r) fallMoves.push({ from: { r, c }, to: { r: target, c }, distance: target - r });
             target--;
           }
         }
         for (let r = target; r >= 0; r--) {
-          next[r][c] = Math.floor(Math.random() * colorCount);
+          next[r][c] = this.createRandomBlock(colorCount);
           spawnMoves.push({ to: { r, c }, distance: r + 1 });
         }
       }
@@ -94,7 +145,7 @@
 
     shuffleBoard(board) {
       const size = board.length;
-      const values = board.flat();
+      const values = board.flat().map(value => this.cloneBlock(value));
       let next;
       do {
         for (let i = values.length - 1; i > 0; i--) {

--- a/assets/match3/main.js
+++ b/assets/match3/main.js
@@ -26,6 +26,36 @@
 
   function updateAttackTimer() { renderBattleStats(); }
 
+  function posKey(pos) { return `${pos.r},${pos.c}`; }
+
+  function specialName(special) {
+    return special === 'line-row' ? '橫列消除' : special === 'line-column' ? '直行消除' : special === 'bomb' ? '九宮格爆炸' : '同色全消';
+  }
+
+  function chooseSpecialAnchor(group) {
+    if (state.selected) {
+      const picked = group.cells.find(cell => cell.r === state.selected.r && cell.c === state.selected.c);
+      if (picked) return picked;
+    }
+    return group.cells[Math.floor(group.cells.length / 2)];
+  }
+
+  function cellsForSpecial(pos) {
+    const block = state.board[pos.r][pos.c];
+    if (!logic.isSpecialBlock(block)) return [];
+    const cells = new Map();
+    const add = (r, c) => { if (r >= 0 && c >= 0 && r < state.size && c < state.size) cells.set(`${r},${c}`, { r, c }); };
+    if (block.special === logic.SPECIAL_TYPES.LINE_ROW) for (let c = 0; c < state.size; c++) add(pos.r, c);
+    else if (block.special === logic.SPECIAL_TYPES.LINE_COLUMN) for (let r = 0; r < state.size; r++) add(r, pos.c);
+    else if (block.special === logic.SPECIAL_TYPES.BOMB) {
+      for (let r = pos.r - 1; r <= pos.r + 1; r++) for (let c = pos.c - 1; c <= pos.c + 1; c++) add(r, c);
+    } else if (block.special === logic.SPECIAL_TYPES.COLOR) {
+      const color = block.color;
+      state.board.forEach((row, r) => row.forEach((value, c) => { if (value !== null && logic.colorOf(value) === color) add(r, c); }));
+    }
+    return Array.from(cells.values());
+  }
+
   function useMagic() {
     if (state.ended || state.magicArmed || state.roundStats.spell < 5) return;
     state.roundStats.spell -= 5;
@@ -74,20 +104,40 @@
   async function handleCellClick(pos) {
     if (state.busy || state.moves <= 0 || state.ended) return;
     state.hint = [];
+    const clickedBlock = state.board[pos.r][pos.c];
+    if (!state.selected && logic.isSpecialBlock(clickedBlock)) {
+      startTimers();
+      state.busy = true;
+      state.moves--;
+      await activateSpecial(pos);
+      state.combo = 1;
+      endTurnCheck();
+      state.busy = false;
+      render();
+      return;
+    }
     if (!state.selected) { state.selected = pos; render(); return; }
     if (!logic.areAdjacent(state.selected, pos)) { state.selected = pos; render(); return; }
+
+    const selectedBlock = state.board[state.selected.r][state.selected.c];
+    if (logic.isSpecialBlock(selectedBlock) && logic.isSpecialBlock(clickedBlock)) {
+      setStatus('特殊方塊互換的連鎖效果已保留，之後可以接在這裡擴充。');
+      state.selected = null;
+      render();
+      return;
+    }
 
     startTimers();
     state.busy = true;
     const previous = state.board;
     state.board = logic.swap(state.board, state.selected, pos);
-    state.selected = null;
     state.moves--;
     render();
     await sleep(120);
 
     if (logic.findMatches(state.board).length === 0) {
       state.board = previous;
+      state.selected = null;
       setStatus('這一步沒有形成三消，已幫你換回來。');
       state.busy = false;
       render();
@@ -96,6 +146,7 @@
 
     try {
       await resolveMatches();
+      state.selected = null;
       state.combo = 1;
       endTurnCheck();
     } catch (error) {
@@ -107,24 +158,55 @@
     }
   }
 
-  async function resolveMatches() {
-    let matches = logic.findMatches(state.board);
-    while (matches.length > 0) {
-      setStatus(`消除 ${matches.length} 個方塊，效果已累積到本輪計時器。`);
-      state.score += matches.length * 20 * state.combo;
-      render({ clearing: matches });
-      await sleep(state.clearSpeed);
-      matches.forEach(({ r, c }) => {
-        const type = blockType(state.board[r][c]);
-        state.roundStats[type.stat] += 1;
-        state.board[r][c] = null;
+  function collectMatchResult() {
+    const groups = logic.findMatchGroups(state.board);
+    const clearing = new Map();
+    const specials = [];
+    groups.forEach(group => {
+      const special = logic.getSpecialForGroup(group);
+      const anchor = special ? chooseSpecialAnchor(group) : null;
+      group.cells.forEach(cell => {
+        if (!anchor || cell.r !== anchor.r || cell.c !== anchor.c) clearing.set(posKey(cell), cell);
       });
-      const collapsed = logic.collapse(state.board, state.colorCount);
-      state.board = collapsed.board;
-      render({ fallMoves: collapsed.fallMoves, spawnMoves: collapsed.spawnMoves });
-      await sleep(state.fallSpeed);
-      state.combo++;
-      matches = logic.findMatches(state.board);
+      if (special && anchor) specials.push({ ...anchor, color: group.color, special });
+    });
+    return { groups, clearing: Array.from(clearing.values()), specials };
+  }
+
+  async function clearCells(cells, message) {
+    if (cells.length === 0) return;
+    setStatus(message);
+    state.score += cells.length * 20 * state.combo;
+    render({ clearing: cells });
+    await sleep(state.clearSpeed);
+    cells.forEach(({ r, c }) => {
+      if (state.board[r][c] === null) return;
+      const type = blockType(logic.colorOf(state.board[r][c]));
+      state.roundStats[type.stat] += 1;
+      state.board[r][c] = null;
+    });
+    const collapsed = logic.collapse(state.board, state.colorCount);
+    state.board = collapsed.board;
+    render({ fallMoves: collapsed.fallMoves, spawnMoves: collapsed.spawnMoves });
+    await sleep(state.fallSpeed);
+    state.combo++;
+  }
+
+  async function activateSpecial(pos) {
+    const block = state.board[pos.r][pos.c];
+    const cells = cellsForSpecial(pos);
+    await clearCells(cells, `啟動「${specialName(block.special)}」特殊方塊，消除 ${cells.length} 個方塊。`);
+    await resolveMatches();
+  }
+
+  async function resolveMatches() {
+    let result = collectMatchResult();
+    while (result.groups.length > 0) {
+      const specialText = result.specials.length ? `，產生 ${result.specials.length} 個特殊方塊` : '';
+      setStatus(`消除 ${result.clearing.length} 個方塊${specialText}，效果已累積到本輪計時器。`);
+      result.specials.forEach(({ r, c, color, special }) => { state.board[r][c] = logic.createSpecialBlock(color, special); });
+      await clearCells(result.clearing, `消除 ${result.clearing.length} 個方塊${specialText}，效果已累積到本輪計時器。`);
+      result = collectMatchResult();
     }
   }
 

--- a/assets/match3/ui/render.js
+++ b/assets/match3/ui/render.js
@@ -55,11 +55,18 @@
         div.setAttribute('aria-label', `第 ${r + 1} 列第 ${c + 1} 欄`);
         if (value === null) div.classList.add('empty');
         else {
-          const type = blockType(value);
+          const isSpecial = window.Match3Logic && window.Match3Logic.isSpecialBlock(value);
+          const special = isSpecial ? value.special : null;
+          const type = blockType(isSpecial ? value.color : value);
           div.style.background = type.color;
           div.dataset.type = type.stat;
-          div.innerHTML = `<span class="cell-icon" aria-hidden="true">${type.icon}</span>`;
-          div.title = type.name;
+          if (isSpecial) {
+            div.dataset.special = special;
+            div.classList.add('special', `special-${special}`);
+          }
+          const specialIcon = special === 'line-row' ? '↔' : special === 'line-column' ? '↕' : special === 'bomb' ? '✹' : special === 'color' ? '🌈' : '';
+          div.innerHTML = `<span class="cell-icon" aria-hidden="true">${type.icon}</span>${specialIcon ? `<span class="special-icon" aria-hidden="true">${specialIcon}</span>` : ''}`;
+          div.title = isSpecial ? `${type.name}特殊方塊：${specialIcon}` : type.name;
           div.addEventListener('click', () => onCellClick(pos));
         }
         if (state.selected && state.selected.r === r && state.selected.c === c) div.classList.add('selected');

--- a/test/match3.test.js
+++ b/test/match3.test.js
@@ -128,6 +128,15 @@ function wait(ms) {
     Number(elements.roundSpell.textContent) + Number(elements.roundHeal.textContent);
   assert.ok(totalAccumulated > 0, 'cleared blocks should accumulate battle effects');
 
+
+
+  const logic = context.window.Match3Logic;
+  assert.equal(logic.getSpecialForGroup({ orientation: 'row', cells: [{}, {}, {}, {}] }), logic.SPECIAL_TYPES.LINE_ROW, 'four in a row should make a horizontal line special');
+  assert.equal(logic.getSpecialForGroup({ orientation: 'column', cells: [{}, {}, {}, {}] }), logic.SPECIAL_TYPES.LINE_COLUMN, 'four in a column should make a vertical line special');
+  assert.equal(logic.getSpecialForGroup({ orientation: 'row', cells: [{}, {}, {}, {}, {}] }), logic.SPECIAL_TYPES.COLOR, 'five matched blocks should make a color-clear special');
+  const special = logic.createSpecialBlock(2, logic.SPECIAL_TYPES.BOMB);
+  assert.equal(logic.colorOf(special), 2, 'special blocks should keep their original color');
+
   elements.resetButton.click();
   assert.equal(elements.board.children.length, 64, 'reset should immediately render the board');
   assert.equal(elements.moves.textContent, 30, 'reset should restore moves');


### PR DESCRIPTION
### Motivation
- 擴充消除效果以支援經典的特殊方塊（4 顆產生直/橫列特殊、5 顆產生同色全消），並在玩家點選時能觸發對應效果以增加玩法深度。 
- 保留日後實作「特殊方塊互換」連鎖效果的延展點，以便未來繼續擴充互動組合。 

### Description
- 在 `assets/match3/core/logic.js` 新增特殊方塊資料結構與工具函式（`SPECIAL_TYPES`、`isSpecialBlock`、`colorOf`、`createSpecialBlock`、`findMatchGroups`、`getSpecialForGroup` 等），並讓版面可以包含一般顏色或帶 `special` 的物件。 
- 在消除流程中判定 4 顆/5 顆配對時建立特殊方塊（4 顆依方向為 `line-row`/`line-column`，5 顆為 `color`），並調整 `collapse`/`shuffle` 以正確處理特殊方塊複製與生成。 
- 在 `assets/match3/main.js` 加入點選特殊方塊的啟動流程（`cellsForSpecial`、`activateSpecial`、`clearCells` 等），點選會分別觸發：橫列/直行消除、九宮格爆炸（3x3）、或同色全消；並保留特殊對特殊交換的提示位置供未來擴充。 
- 在 `assets/match3/ui/render.js` 與 `assets/match3.css` 加入特殊方塊的 UI 呈現（徽章圖示與動畫樣式），讓玩家能辨識特殊方塊與其類型。 
- 在 `test/match3.test.js` 補上單元檢查，驗證 `getSpecialForGroup` 與 `createSpecialBlock` / `colorOf` 行為符合規則。 

### Testing
- 執行 `node --test`（包含修改後的 `test/match3.test.js`）所有測試通過。 
- 已驗證遊戲初始渲染、提示功能、一次交換/消除流程仍然可用，且新增的特殊方塊規則會產生正確的特殊方塊。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3240501bc48332af82c13c2fcd3b0b)