### PR TITLE
Add debug options toggle, damage popups, and 4-match line-pair combo

### DIFF
--- a/assets/match3.css
+++ b/assets/match3.css
@@ -95,3 +95,23 @@ button:disabled { opacity: .55; cursor: not-allowed; }
 .special-icon { position: absolute; right: 2px; bottom: 0; display: grid; place-items: center; width: 18px; height: 18px; border-radius: 999px; background: rgba(17,24,39,.82); color: white; font-size: 12px; line-height: 1; z-index: 1; }
 .cell-icon { position: relative; z-index: 1; }
 @keyframes special-spin { to { transform: rotate(360deg); } }
+.damage-popup {
+  position: absolute;
+  top: -20px;
+  left: 50%;
+  z-index: 3;
+  pointer-events: none;
+  transform: translateX(-50%);
+  color: #dc2626;
+  font-size: 22px;
+  font-weight: 900;
+  text-shadow: 0 2px 0 #fff, 0 0 8px rgba(255,255,255,.9);
+  animation: damage-float 900ms ease-out forwards;
+}
+.damage-popup.heal { color: #16a34a; }
+@keyframes damage-float {
+  from { opacity: 0; transform: translate(-50%, 8px) scale(.85); }
+  20% { opacity: 1; transform: translate(-50%, 0) scale(1.15); }
+  to { opacity: 0; transform: translate(-50%, -34px) scale(1); }
+}
+.fighter { position: relative; }

--- a/assets/match3/main.js
+++ b/assets/match3/main.js
@@ -4,6 +4,16 @@
   const { createState, resetRoundStats } = window.Match3State;
   const { $, clamp, setStatus } = window.Match3Dom;
   const state = createState();
+  const showDebugOptions = (() => {
+    const search = window.location && window.location.search ? window.location.search : '';
+    const debugMatch = search.match(/[?&]debugOptions=([^&]*)/);
+    if (debugMatch) {
+      const value = decodeURIComponent(debugMatch[1]);
+      return value !== 'false' && value !== '0';
+    }
+    if (/[?&]debugOptions(?:&|$)/.test(search)) return true;
+    return window.MATCH3_SHOW_DEBUG_OPTIONS === true;
+  })();
 
   function sleep(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }
   function sleepMsFromSeconds(seconds) { return Math.max(1, Number(seconds)) * 1000; }
@@ -60,6 +70,13 @@
     if (value === null) return state.clearSpeed;
     const type = blockType(logic.colorOf(value));
     return Math.max(1, Number(type.clearSpeed) || state.clearSpeed);
+  }
+
+  function applyDebugOptionVisibility() {
+    if (!document.querySelectorAll) return;
+    document.querySelectorAll('[data-debug-option]').forEach(element => {
+      element.hidden = !showDebugOptions;
+    });
   }
 
   function renderBlockSettings() {
@@ -244,15 +261,36 @@
   }
 
 
+  function isLineSpecial(block) {
+    return logic.isSpecialBlock(block) && (block.special === logic.SPECIAL_TYPES.LINE_ROW || block.special === logic.SPECIAL_TYPES.LINE_COLUMN);
+  }
+
+  function cellsForLineSpecialPair(first, second) {
+    const cells = new Map();
+    for (let c = 0; c < state.size; c++) cells.set(posKey({ r: first.r, c }), { r: first.r, c });
+    for (let r = 0; r < state.size; r++) cells.set(posKey({ r, c: second.c }), { r, c: second.c });
+    cells.set(posKey(first), first);
+    cells.set(posKey(second), second);
+    return Array.from(cells.values());
+  }
+
   async function activateSpecialPair(first, second) {
     const firstBlock = state.board[first.r][first.c];
     const secondBlock = state.board[second.r][second.c];
+    const linePair = isLineSpecial(firstBlock) && isLineSpecial(secondBlock);
     const cells = new Map();
-    [first, second].forEach(pos => cellsForSpecial(pos).forEach(cell => cells.set(posKey(cell), cell)));
-    cells.set(posKey(first), first);
-    cells.set(posKey(second), second);
-    await clearCells(Array.from(cells.values()), `啟動兩顆特殊方塊，合併消除 ${cells.size} 個方塊並累積效果。`);
-    state.lastAction = `特殊方塊連鎖：${specialName(firstBlock.special)} + ${specialName(secondBlock.special)}。`;
+    if (linePair) {
+      cellsForLineSpecialPair(first, second).forEach(cell => cells.set(posKey(cell), cell));
+    } else {
+      [first, second].forEach(pos => cellsForSpecial(pos).forEach(cell => cells.set(posKey(cell), cell)));
+      cells.set(posKey(first), first);
+      cells.set(posKey(second), second);
+    }
+    const message = linePair
+      ? `兩顆四消特殊方塊交換，改為消除 1 條橫列與 1 條直行，共 ${cells.size} 格。`
+      : `啟動兩顆特殊方塊，合併消除 ${cells.size} 個方塊並累積效果。`;
+    await clearCells(Array.from(cells.values()), message);
+    state.lastAction = linePair ? '特殊方塊連鎖：四消 + 四消，消除橫列與直行。' : `特殊方塊連鎖：${specialName(firstBlock.special)} + ${specialName(secondBlock.special)}。`;
     await resolveMatches();
   }
 
@@ -288,6 +326,8 @@
     render();
   }
 
+  applyDebugOptionVisibility();
+
   const renderer = window.Match3Renderer.createRenderer({ state, blockType, formatCountdown, countdownProgress, onCellClick: handleCellClick });
   render = renderer.render;
   renderBattleStats = renderer.renderBattleStats;
@@ -306,5 +346,5 @@
   $('magicButton').addEventListener('click', useMagic);
   resetGame();
 
-  window.Match3Game = { state, resetGame, handleCellClick, resolveMatches, playerAttack, enemyAttack };
+  window.Match3Game = { state, resetGame, handleCellClick, resolveMatches, playerAttack, enemyAttack, showDebugOptions };
 })();

--- a/assets/match3/state/game-state.js
+++ b/assets/match3/state/game-state.js
@@ -15,7 +15,7 @@
       attackMultiplier: 1, defenseMultiplier: 1, enemyAttackPower: ENEMY_ATTACK,
       attackInterval: 5, enemyInterval: 5, nextPlayerAttackAt: null, nextEnemyAttackAt: null,
       roundStats: createRoundStats(),
-      lastAction: '尚未攻擊。', heroAction: false, enemyAction: false, ended: false, magicArmed: false
+      lastAction: '尚未攻擊。', heroAction: false, enemyAction: false, damagePopups: [], ended: false, magicArmed: false
     };
   }
 

--- a/assets/match3/systems/battle.js
+++ b/assets/match3/systems/battle.js
@@ -1,5 +1,16 @@
 (function (global) {
   function createBattleSystem({ state, render, setStatus, clamp, sleepMsFromSeconds, stopTimers, resetRoundStats, formatNumber }) {
+    function showDamagePopup(target, amount, kind = 'damage') {
+      const id = `${Date.now()}-${Math.random()}`;
+      const prefix = kind === 'heal' ? '+' : '-';
+      state.damagePopups = [{ id, target, kind, text: `${prefix}${formatNumber(amount)}` }];
+      render();
+      setTimeout(() => {
+        state.damagePopups = state.damagePopups.filter(popup => popup.id !== id);
+        render();
+      }, 900);
+    }
+
     function flashActor(actor) {
       if (actor === 'hero') state.heroAction = true;
       else state.enemyAction = true;
@@ -20,6 +31,7 @@
       const heal = state.roundStats.heal;
       state.enemyHp = clamp(state.enemyHp - damage, 0, state.enemyMaxHp);
       state.playerHp = clamp(state.playerHp + heal, 0, state.playerMaxHp);
+      showDamagePopup('enemy', damage);
       state.lastAction = `我方攻擊造成 ${formatNumber(damage)} 傷害${state.magicArmed ? '（魔法 x2）' : ''}，回血 ${formatNumber(heal)}。防禦會保留到敵方攻擊結算。`;
       state.roundStats.attack = 0;
       state.roundStats.spell = 0;
@@ -35,6 +47,7 @@
       const blocked = Math.min(state.enemyAttackPower, state.roundStats.defense * state.defenseMultiplier);
       const damage = state.enemyAttackPower - blocked;
       state.playerHp = clamp(state.playerHp - damage, 0, state.playerMaxHp);
+      showDamagePopup('hero', damage);
       state.lastAction = `敵方攻擊 ${formatNumber(state.enemyAttackPower)}，防禦方塊抵擋 ${formatNumber(blocked)}，我方受到 ${formatNumber(damage)} 傷害。`;
       resetRoundStats(state);
       state.nextEnemyAttackAt = Date.now() + sleepMsFromSeconds(state.enemyInterval);

--- a/assets/match3/ui/render.js
+++ b/assets/match3/ui/render.js
@@ -109,6 +109,19 @@
       $('roundSpell').textContent = state.roundStats.spell;
       $('roundHeal').textContent = state.roundStats.heal;
       $('battleLog').textContent = state.lastAction;
+      const heroFighter = $('heroSprite').parentElement;
+      const enemyFighter = $('enemySprite').parentElement;
+      if (heroFighter && enemyFighter) {
+        heroFighter.querySelectorAll('.damage-popup').forEach(element => element.remove());
+        enemyFighter.querySelectorAll('.damage-popup').forEach(element => element.remove());
+        state.damagePopups.forEach(popup => {
+          const target = popup.target === 'enemy' ? enemyFighter : heroFighter;
+          const label = document.createElement('span');
+          label.className = `damage-popup ${popup.kind || 'damage'}`;
+          label.textContent = popup.text;
+          target.appendChild(label);
+        });
+      }
       $('heroSprite').classList.toggle('attacking', state.heroAction);
       $('enemySprite').classList.toggle('attacking', state.enemyAction);
       $('hintButton').disabled = state.busy || state.ended;

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     </section>
 
     <section class="panel controls" aria-label="遊戲設定">
-      <label>顏色數量
+      <label data-debug-option>顏色數量
         <select id="colorCount">
           <option value="3">3</option>
           <option value="4" selected>4</option>
@@ -23,7 +23,7 @@
           <option value="6">6</option>
         </select>
       </label>
-      <label>版面大小
+      <label data-debug-option>版面大小
         <select id="boardSize">
           <option value="6">6x6</option>
           <option value="7">7x7</option>
@@ -31,36 +31,36 @@
           <option value="9">9x9</option>
         </select>
       </label>
-      <label>下落速度(ms)
+      <label data-debug-option>下落速度(ms)
         <input type="number" id="fallSpeed" value="420" min="120" max="1200" step="10" />
       </label>
-      <label>消除速度(ms)
+      <label data-debug-option>消除速度(ms)
         <input type="number" id="clearSpeed" value="260" min="80" max="1000" step="10" />
       </label>
-      <details class="block-settings">
+      <details class="block-settings" data-debug-option>
         <summary>每種方塊參數</summary>
         <p>出現權重越高越常出現；消除速度會套用在該方塊的消除動畫。</p>
         <div id="blockSettings" class="block-settings-grid"></div>
       </details>
-      <label>我方攻擊頻率(秒)
+      <label data-debug-option>我方攻擊頻率(秒)
         <input type="number" id="attackInterval" value="5" min="1" max="30" step="1" />
       </label>
-      <label>敵方攻擊頻率(秒)
+      <label data-debug-option>敵方攻擊頻率(秒)
         <input type="number" id="enemyInterval" value="5" min="1" max="30" step="1" />
       </label>
-      <label>我方血量
+      <label data-debug-option>我方血量
         <input type="number" id="playerMaxHpInput" value="100" min="1" max="999" step="1" />
       </label>
-      <label>敵方血量
+      <label data-debug-option>敵方血量
         <input type="number" id="enemyMaxHpInput" value="100" min="1" max="999" step="1" />
       </label>
-      <label>攻擊力倍數
+      <label data-debug-option>攻擊力倍數
         <input type="number" id="attackMultiplier" value="1" min="0" max="99" step="0.1" />
       </label>
-      <label>防禦力倍數
+      <label data-debug-option>防禦力倍數
         <input type="number" id="defenseMultiplier" value="1" min="0" max="99" step="0.1" />
       </label>
-      <label>敵方攻擊力
+      <label data-debug-option>敵方攻擊力
         <input type="number" id="enemyAttackPower" value="10" min="0" max="999" step="1" />
       </label>
       <button id="resetButton" type="button">重設遊戲</button>

--- a/test/match3.test.js
+++ b/test/match3.test.js
@@ -107,6 +107,7 @@ function wait(ms) {
   assert.equal(elements.enemyHp.textContent, '150/150');
   assert.equal(elements.moves.textContent, 30);
   assert.equal(elements.healValue.textContent, '0 / 100', 'heal should have an accumulation meter');
+  assert.equal(context.window.Match3Game.showDebugOptions, false, 'debug option controls should be hidden by default');
 
   elements.hintButton.click();
   assert.equal(elements.board.children.filter(cell => cell.classList.contains('hint')).length, 2, 'hint should mark one swappable pair');
@@ -168,6 +169,13 @@ function wait(ms) {
   await specialActivation;
   assert.ok(Number(elements.roundAttack.textContent) > 0, 'activated special blocks should accumulate cleared block effects');
   context.window.Match3Config.BLOCK_TYPES[0].clearSpeed = 260;
+
+  elements.resetButton.click();
+  context.window.Match3Game.state.roundStats.attack = 7;
+  context.window.Match3Game.state.attackMultiplier = 2;
+  context.window.Match3Game.playerAttack();
+  assert.equal(context.window.Match3Game.state.enemyHp, 136, 'player attack should apply the actual calculated damage');
+  assert.equal(context.window.Match3Game.state.damagePopups[0].text, '-14', 'player attack should create a damage number popup');
 
   elements.resetButton.click();
   assert.equal(elements.board.children.length, 64, 'reset should immediately render the board');


### PR DESCRIPTION
### Motivation
- Provide a single switch to hide/show the current debug/tuning controls so the UI can appear production-like by default. 
- Surface the actual damage numbers produced by each attack so players can see real-time feedback above the characters. 
- Implement the intended behavior when swapping two four-match line specials so the swap clears one full row and one full column.

### Description
- Hide tuning controls by marking their labels/containers with `data-debug-option` and added a `showDebugOptions` check that can be enabled with `?debugOptions=true` or by setting `window.MATCH3_SHOW_DEBUG_OPTIONS` before load, and applied via `applyDebugOptionVisibility()` in `assets/match3/main.js` and `index.html` updates. 
- Add `damagePopups` to the game state and a `showDamagePopup` helper in `assets/match3/systems/battle.js` that is called on player and enemy attack resolution to push a popup entry. 
- Render floating damage/heal popups in `assets/match3/ui/render.js` and add CSS animation rules in `assets/match3.css` so numbers appear above the relevant fighter and fade upward. 
- Detect and handle the special case of swapping two line-type specials (four-match specials) by clearing one horizontal row and one vertical column in `assets/match3/main.js` using `cellsForLineSpecialPair`, and update messages/`lastAction` accordingly. 
- Update tests (`test/match3.test.js`) to assert default debug controls are hidden and that a player attack produces the expected damage popup state.

### Testing
- Ran the automated test suite with `npm test` and the updated tests passed. 
- The unit test `test/match3.test.js` was extended to cover default debug visibility and damage popup creation and succeeded. 
- Attempted a headless page screenshot via Playwright to verify UI debug mode, but Playwright is not installed in the environment so the visual check was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3250fbee948332b9ffa8fe29b6a56e)