### PR TITLE
Validate board rendering on reset

### DIFF
--- a/assets/match3/main.js
+++ b/assets/match3/main.js
@@ -18,6 +18,18 @@
   function sleep(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }
   function sleepMsFromSeconds(seconds) { return Math.max(1, Number(seconds)) * 1000; }
   function formatNumber(value) { return Number.isInteger(value) ? String(value) : value.toFixed(1); }
+
+  function readNumberInput(id, fallback, { min = -Infinity, max = Infinity } = {}) {
+    const raw = $(id).value;
+    const value = raw === '' || raw === null || raw === undefined ? NaN : Number(raw);
+    const safe = Number.isFinite(value) ? value : fallback;
+    return clamp(safe, min, max);
+  }
+
+  function readIntegerInput(id, fallback, range) {
+    return Math.round(readNumberInput(id, fallback, range));
+  }
+
   function formatCountdown(target) {
     if (!target || state.ended) return '--';
     return `${Math.max(0, Math.ceil((target - Date.now()) / 1000))}s`;
@@ -143,9 +155,11 @@
 
   function resetGame() {
     stopTimers();
-    const playerMaxHp = Math.max(1, Number($('playerMaxHpInput').value));
-    const enemyMaxHp = Math.max(1, Number($('enemyMaxHpInput').value));
-    Object.assign(state, { size: Number($('boardSize').value), colorCount: Number($('colorCount').value), fallSpeed: Number($('fallSpeed').value), clearSpeed: Number($('clearSpeed').value), attackInterval: Number($('attackInterval').value), enemyInterval: Number($('enemyInterval').value), attackMultiplier: Math.max(0, Number($('attackMultiplier').value)), defenseMultiplier: Math.max(0, Number($('defenseMultiplier').value)), enemyAttackPower: Math.max(0, Number($('enemyAttackPower').value)), selected: null, busy: false, score: 0, moves: 30, target: Number($('boardSize').value) * 150, combo: 1, startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null, hint: [], playerHp: playerMaxHp, enemyHp: enemyMaxHp, playerMaxHp, enemyMaxHp, nextPlayerAttackAt: null, nextEnemyAttackAt: null, lastAction: '交換方塊後，雙方攻擊計時器會開始。', heroAction: false, enemyAction: false, ended: false, magicArmed: false });
+    const size = readIntegerInput('boardSize', state.size || 8, { min: 3, max: 12 });
+    const colorCount = readIntegerInput('colorCount', state.colorCount || 4, { min: 3, max: BLOCK_TYPES.length });
+    const playerMaxHp = readIntegerInput('playerMaxHpInput', state.playerMaxHp || 100, { min: 1, max: 9999 });
+    const enemyMaxHp = readIntegerInput('enemyMaxHpInput', state.enemyMaxHp || 100, { min: 1, max: 9999 });
+    Object.assign(state, { size, colorCount, fallSpeed: readNumberInput('fallSpeed', state.fallSpeed || 420, { min: 1, max: 5000 }), clearSpeed: readNumberInput('clearSpeed', state.clearSpeed || 260, { min: 1, max: 5000 }), attackInterval: readNumberInput('attackInterval', state.attackInterval || 5, { min: 1, max: 3600 }), enemyInterval: readNumberInput('enemyInterval', state.enemyInterval || 5, { min: 1, max: 3600 }), attackMultiplier: readNumberInput('attackMultiplier', state.attackMultiplier || 1, { min: 0, max: 999 }), defenseMultiplier: readNumberInput('defenseMultiplier', state.defenseMultiplier || 1, { min: 0, max: 999 }), enemyAttackPower: readNumberInput('enemyAttackPower', state.enemyAttackPower || 10, { min: 0, max: 9999 }), selected: null, busy: false, score: 0, moves: 30, target: size * 150, combo: 1, startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null, hint: [], playerHp: playerMaxHp, enemyHp: enemyMaxHp, playerMaxHp, enemyMaxHp, nextPlayerAttackAt: null, nextEnemyAttackAt: null, lastAction: '交換方塊後，雙方攻擊計時器會開始。', heroAction: false, enemyAction: false, ended: false, magicArmed: false });
     resetRoundStats(state);
     state.board = logic.createBoard(state.size, state.colorCount);
     renderBlockSettings();

--- a/test/match3.test.js
+++ b/test/match3.test.js
@@ -98,10 +98,16 @@ function wait(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function assertBoardPanelRendered(elements, expectedSize, message) {
+  assert.equal(elements.board.children.length, expectedSize * expectedSize, `${message}: board should render ${expectedSize * expectedSize} cells`);
+  assert.equal(elements.board.children.filter(cell => !cell.classList.contains('empty')).length, expectedSize * expectedSize, `${message}: board cells should be visible blocks`);
+  assert.ok(elements.board.children.every(cell => cell.listeners.click), `${message}: every visible block should be clickable`);
+}
+
 (async () => {
   const { context, elements } = createHarness();
 
-  assert.equal(elements.board.children.length, 64, 'initial board should render 8x8 cells');
+  assertBoardPanelRendered(elements, 8, 'initial load');
   assert.equal(elements.status.textContent, '請交換相鄰方塊開始遊戲。');
   assert.equal(elements.playerHp.textContent, '120/120');
   assert.equal(elements.enemyHp.textContent, '150/150');
@@ -125,7 +131,7 @@ function wait(ms) {
   await wait(1000);
 
   assert.equal(elements.moves.textContent, 29, 'valid swap should consume one move');
-  assert.equal(elements.board.children.length, 64, 'board should still have 64 cells after resolving a move');
+  assertBoardPanelRendered(elements, 8, 'after resolving a move');
   assert.doesNotThrow(() => context.window.Match3Logic.findAvailableMove(currentBoard()));
   const totalAccumulated = Number(elements.roundAttack.textContent) + Number(elements.roundDefense.textContent) +
     Number(elements.roundSpell.textContent) + Number(elements.roundHeal.textContent);
@@ -178,8 +184,16 @@ function wait(ms) {
   assert.equal(context.window.Match3Game.state.damagePopups[0].text, '-14', 'player attack should create a damage number popup');
 
   elements.resetButton.click();
-  assert.equal(elements.board.children.length, 64, 'reset should immediately render the board');
+  assertBoardPanelRendered(elements, 8, 'reset');
   assert.equal(elements.moves.textContent, 30, 'reset should restore moves');
+
+  elements.boardSize.value = '';
+  elements.colorCount.value = '';
+  elements.fallSpeed.value = '';
+  elements.clearSpeed.value = '';
+  elements.resetButton.click();
+  assertBoardPanelRendered(elements, 8, 'reset with blank settings');
+  assert.equal(elements.target.textContent, 1200, 'blank board size should fall back without hiding the board');
 
   console.log('match3 basic UI tests passed');
 })().catch(error => {


### PR DESCRIPTION
### Motivation
- 避免在重設遊戲時，若輸入欄位為空或不合法數字導致棋盤尺寸或顏色數為 `NaN`/0，造成方塊面板消失的常見 bug。 

### Description
- 新增 `readNumberInput` 和 `readIntegerInput`（`assets/match3/main.js`）用來安全地解析、回退與限制數值輸入。 
- 在 `resetGame` 中改用上述讀取函式來設定 `size`、`colorCount`、`fallSpeed`、`clearSpeed`、`attackInterval`、`enemyInterval`、`attackMultiplier`、`defenseMultiplier` 與 `enemyAttackPower`，以確保空值或非法輸入會回退到合理預設/先前值。 
- 新增測試輔助函式 `assertBoardPanelRendered` 並在 `test/match3.test.js` 中加入檢查，覆蓋初次載入、交換後、重設，以及「欄位為空再重設」情境，確保棋盤持續正確渲染。 

### Testing
- 執行 `npm test`，所有測試通過並輸出 `match3 basic UI tests passed`。 
- 新增的測試斷言驗證了在重設（包括空白輸入）後棋盤仍正確渲染為預期尺寸並可互動。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a325e0f83f08332899682999e75adad)