### PR TITLE
Validate and clamp match3 inputs, always show block-settings panel, and update tests

### DIFF
--- a/assets/match3/main.js
+++ b/assets/match3/main.js
@@ -18,6 +18,18 @@
   function sleep(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }
   function sleepMsFromSeconds(seconds) { return Math.max(1, Number(seconds)) * 1000; }
   function formatNumber(value) { return Number.isInteger(value) ? String(value) : value.toFixed(1); }
+
+  function readNumberInput(id, fallback, { min = -Infinity, max = Infinity } = {}) {
+    const raw = $(id).value;
+    const value = raw === '' || raw === null || raw === undefined ? NaN : Number(raw);
+    const safe = Number.isFinite(value) ? value : fallback;
+    return clamp(safe, min, max);
+  }
+
+  function readIntegerInput(id, fallback, range) {
+    return Math.round(readNumberInput(id, fallback, range));
+  }
+
   function formatCountdown(target) {
     if (!target || state.ended) return '--';
     return `${Math.max(0, Math.ceil((target - Date.now()) / 1000))}s`;
@@ -143,9 +155,11 @@
 
   function resetGame() {
     stopTimers();
-    const playerMaxHp = Math.max(1, Number($('playerMaxHpInput').value));
-    const enemyMaxHp = Math.max(1, Number($('enemyMaxHpInput').value));
-    Object.assign(state, { size: Number($('boardSize').value), colorCount: Number($('colorCount').value), fallSpeed: Number($('fallSpeed').value), clearSpeed: Number($('clearSpeed').value), attackInterval: Number($('attackInterval').value), enemyInterval: Number($('enemyInterval').value), attackMultiplier: Math.max(0, Number($('attackMultiplier').value)), defenseMultiplier: Math.max(0, Number($('defenseMultiplier').value)), enemyAttackPower: Math.max(0, Number($('enemyAttackPower').value)), selected: null, busy: false, score: 0, moves: 30, target: Number($('boardSize').value) * 150, combo: 1, startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null, hint: [], playerHp: playerMaxHp, enemyHp: enemyMaxHp, playerMaxHp, enemyMaxHp, nextPlayerAttackAt: null, nextEnemyAttackAt: null, lastAction: '交換方塊後，雙方攻擊計時器會開始。', heroAction: false, enemyAction: false, ended: false, magicArmed: false });
+    const size = readIntegerInput('boardSize', state.size || 8, { min: 3, max: 12 });
+    const colorCount = readIntegerInput('colorCount', state.colorCount || 4, { min: 3, max: BLOCK_TYPES.length });
+    const playerMaxHp = readIntegerInput('playerMaxHpInput', state.playerMaxHp || 100, { min: 1, max: 9999 });
+    const enemyMaxHp = readIntegerInput('enemyMaxHpInput', state.enemyMaxHp || 100, { min: 1, max: 9999 });
+    Object.assign(state, { size, colorCount, fallSpeed: readNumberInput('fallSpeed', state.fallSpeed || 420, { min: 1, max: 5000 }), clearSpeed: readNumberInput('clearSpeed', state.clearSpeed || 260, { min: 1, max: 5000 }), attackInterval: readNumberInput('attackInterval', state.attackInterval || 5, { min: 1, max: 3600 }), enemyInterval: readNumberInput('enemyInterval', state.enemyInterval || 5, { min: 1, max: 3600 }), attackMultiplier: readNumberInput('attackMultiplier', state.attackMultiplier || 1, { min: 0, max: 999 }), defenseMultiplier: readNumberInput('defenseMultiplier', state.defenseMultiplier || 1, { min: 0, max: 999 }), enemyAttackPower: readNumberInput('enemyAttackPower', state.enemyAttackPower || 10, { min: 0, max: 9999 }), selected: null, busy: false, score: 0, moves: 30, target: size * 150, combo: 1, startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null, hint: [], playerHp: playerMaxHp, enemyHp: enemyMaxHp, playerMaxHp, enemyMaxHp, nextPlayerAttackAt: null, nextEnemyAttackAt: null, lastAction: '交換方塊後，雙方攻擊計時器會開始。', heroAction: false, enemyAction: false, ended: false, magicArmed: false });
     resetRoundStats(state);
     state.board = logic.createBoard(state.size, state.colorCount);
     renderBlockSettings();

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
       <label data-debug-option>消除速度(ms)
         <input type="number" id="clearSpeed" value="260" min="80" max="1000" step="10" />
       </label>
-      <details class="block-settings" data-debug-option>
+      <details class="block-settings">
         <summary>每種方塊參數</summary>
         <p>出現權重越高越常出現；消除速度會套用在該方塊的消除動畫。</p>
         <div id="blockSettings" class="block-settings-grid"></div>

--- a/test/match3.test.js
+++ b/test/match3.test.js
@@ -98,16 +98,24 @@ function wait(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function assertBoardPanelRendered(elements, expectedSize, message) {
+  assert.equal(elements.board.children.length, expectedSize * expectedSize, `${message}: board should render ${expectedSize * expectedSize} cells`);
+  assert.equal(elements.board.children.filter(cell => !cell.classList.contains('empty')).length, expectedSize * expectedSize, `${message}: board cells should be visible blocks`);
+  assert.ok(elements.board.children.every(cell => cell.listeners.click), `${message}: every visible block should be clickable`);
+}
+
 (async () => {
   const { context, elements } = createHarness();
 
-  assert.equal(elements.board.children.length, 64, 'initial board should render 8x8 cells');
+  assertBoardPanelRendered(elements, 8, 'initial load');
   assert.equal(elements.status.textContent, '請交換相鄰方塊開始遊戲。');
   assert.equal(elements.playerHp.textContent, '120/120');
   assert.equal(elements.enemyHp.textContent, '150/150');
   assert.equal(elements.moves.textContent, 30);
   assert.equal(elements.healValue.textContent, '0 / 100', 'heal should have an accumulation meter');
   assert.equal(context.window.Match3Game.showDebugOptions, false, 'debug option controls should be hidden by default');
+  assert.equal(elements.blockSettings.children.length, 4, 'block settings panel should render one card per active block type');
+  assert.doesNotMatch(fs.readFileSync('index.html', 'utf8'), /<details class="block-settings"[^>]*data-debug-option/, 'block settings panel should stay visible without debug options');
 
   elements.hintButton.click();
   assert.equal(elements.board.children.filter(cell => cell.classList.contains('hint')).length, 2, 'hint should mark one swappable pair');
@@ -125,7 +133,7 @@ function wait(ms) {
   await wait(1000);
 
   assert.equal(elements.moves.textContent, 29, 'valid swap should consume one move');
-  assert.equal(elements.board.children.length, 64, 'board should still have 64 cells after resolving a move');
+  assertBoardPanelRendered(elements, 8, 'after resolving a move');
   assert.doesNotThrow(() => context.window.Match3Logic.findAvailableMove(currentBoard()));
   const totalAccumulated = Number(elements.roundAttack.textContent) + Number(elements.roundDefense.textContent) +
     Number(elements.roundSpell.textContent) + Number(elements.roundHeal.textContent);
@@ -178,8 +186,16 @@ function wait(ms) {
   assert.equal(context.window.Match3Game.state.damagePopups[0].text, '-14', 'player attack should create a damage number popup');
 
   elements.resetButton.click();
-  assert.equal(elements.board.children.length, 64, 'reset should immediately render the board');
+  assertBoardPanelRendered(elements, 8, 'reset');
   assert.equal(elements.moves.textContent, 30, 'reset should restore moves');
+
+  elements.boardSize.value = '';
+  elements.colorCount.value = '';
+  elements.fallSpeed.value = '';
+  elements.clearSpeed.value = '';
+  elements.resetButton.click();
+  assertBoardPanelRendered(elements, 8, 'reset with blank settings');
+  assert.equal(elements.target.textContent, 1200, 'blank board size should fall back without hiding the board');
 
   console.log('match3 basic UI tests passed');
 })().catch(error => {


### PR DESCRIPTION
### Motivation
- Make reading of numeric controls more robust by treating blank or invalid values as fallbacks and clamping them to sensible ranges. 
- Ensure the per-block settings panel is visible even when debug controls are hidden so its controls remain accessible for tuning. 

### Description
- Add helper functions `readNumberInput` and `readIntegerInput` to parse, fallback, and clamp numeric inputs. 
- Replace direct `Number(...)` DOM reads in `resetGame` with calls to `readNumberInput`/`readIntegerInput` for `boardSize`, `colorCount`, `playerMaxHp`, `enemyMaxHp`, `fallSpeed`, `clearSpeed`, `attackInterval`, `enemyInterval`, `attackMultiplier`, `defenseMultiplier`, and `enemyAttackPower`. 
- Remove the `data-debug-option` attribute from the `<details class="block-settings">` element in `index.html` so the block settings panel remains visible. 
- Update `test/match3.test.js` by adding `assertBoardPanelRendered` helper and expanding assertions to validate board rendering, block-settings rendering, and behavior when settings inputs are blank. 

### Testing
- Ran the updated unit test script `test/match3.test.js` which includes the new rendering and blank-input assertions, and all assertions passed. 
- Existing logic and battle system tests in the same harness were executed and continued to pass. 
- No automated tests failed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a325e0f83f08332899682999e75adad)