### PR TITLE
Fix battle popups and default block rates

### DIFF
--- a/assets/match3/config/block-types.js
+++ b/assets/match3/config/block-types.js
@@ -1,9 +1,9 @@
 (function (global) {
   const BLOCK_TYPES = [
-    { name: '攻擊', icon: '⚔', color: '#FF6663', stat: 'attack', weight: 1, clearSpeed: 260 },
-    { name: '防禦', icon: '🛡', color: '#60A5FA', stat: 'defense', weight: 1, clearSpeed: 260 },
-    { name: '法術', icon: '✦', color: '#A78BFA', stat: 'spell', weight: 1, clearSpeed: 260 },
-    { name: '回血', icon: '❤', color: '#34D399', stat: 'heal', weight: 1, clearSpeed: 260 },
+    { name: '攻擊', icon: '⚔', color: '#FF6663', stat: 'attack', weight: 35, clearSpeed: 260 },
+    { name: '防禦', icon: '🛡', color: '#60A5FA', stat: 'defense', weight: 35, clearSpeed: 260 },
+    { name: '法術', icon: '✦', color: '#A78BFA', stat: 'spell', weight: 20, clearSpeed: 260 },
+    { name: '回血', icon: '❤', color: '#34D399', stat: 'heal', weight: 10, clearSpeed: 260 },
     { name: '火焰', icon: '🔥', color: '#FEB144', stat: 'attack', weight: 1, clearSpeed: 260 },
     { name: '自然', icon: '☘', color: '#9EE09E', stat: 'heal', weight: 1, clearSpeed: 260 },
     { name: '星光', icon: '★', color: '#FDE68A', stat: 'spell', weight: 1, clearSpeed: 260 }

--- a/assets/match3/systems/battle.js
+++ b/assets/match3/systems/battle.js
@@ -3,7 +3,7 @@
     function showDamagePopup(target, amount, kind = 'damage') {
       const id = `${Date.now()}-${Math.random()}`;
       const prefix = kind === 'heal' ? '+' : '-';
-      state.damagePopups = [{ id, target, kind, text: `${prefix}${formatNumber(amount)}` }];
+      state.damagePopups = [...state.damagePopups, { id, target, kind, text: `${prefix}${formatNumber(amount)}` }];
       render();
       setTimeout(() => {
         state.damagePopups = state.damagePopups.filter(popup => popup.id !== id);
@@ -29,10 +29,13 @@
       const baseDamage = (state.roundStats.attack * state.attackMultiplier) + (state.roundStats.spell * 2);
       const damage = state.magicArmed ? baseDamage * 2 : baseDamage;
       const heal = state.roundStats.heal;
+      const playerHpBeforeHeal = state.playerHp;
       state.enemyHp = clamp(state.enemyHp - damage, 0, state.enemyMaxHp);
       state.playerHp = clamp(state.playerHp + heal, 0, state.playerMaxHp);
-      showDamagePopup('enemy', damage);
-      state.lastAction = `我方攻擊造成 ${formatNumber(damage)} 傷害${state.magicArmed ? '（魔法 x2）' : ''}，回血 ${formatNumber(heal)}。防禦會保留到敵方攻擊結算。`;
+      const actualHeal = state.playerHp - playerHpBeforeHeal;
+      if (damage > 0) showDamagePopup('enemy', damage);
+      if (actualHeal > 0) showDamagePopup('hero', actualHeal, 'heal');
+      state.lastAction = `我方攻擊造成 ${formatNumber(damage)} 傷害${state.magicArmed ? '（魔法 x2）' : ''}，回血 ${formatNumber(actualHeal)}。防禦會保留到敵方攻擊結算。`;
       state.roundStats.attack = 0;
       state.roundStats.spell = 0;
       state.roundStats.heal = 0;
@@ -47,7 +50,7 @@
       const blocked = Math.min(state.enemyAttackPower, state.roundStats.defense * state.defenseMultiplier);
       const damage = state.enemyAttackPower - blocked;
       state.playerHp = clamp(state.playerHp - damage, 0, state.playerMaxHp);
-      showDamagePopup('hero', damage);
+      if (damage > 0) showDamagePopup('hero', damage);
       state.lastAction = `敵方攻擊 ${formatNumber(state.enemyAttackPower)}，防禦方塊抵擋 ${formatNumber(blocked)}，我方受到 ${formatNumber(damage)} 傷害。`;
       resetRoundStats(state);
       state.nextEnemyAttackAt = Date.now() + sleepMsFromSeconds(state.enemyInterval);

--- a/test/match3.test.js
+++ b/test/match3.test.js
@@ -148,11 +148,17 @@ function assertBoardPanelRendered(elements, expectedSize, message) {
   const special = logic.createSpecialBlock(2, logic.SPECIAL_TYPES.BOMB);
   assert.equal(logic.colorOf(special), 2, 'special blocks should keep their original color');
 
+  assert.equal(
+    JSON.stringify(context.window.Match3Config.BLOCK_TYPES.slice(0, 4).map(type => type.weight)),
+    JSON.stringify([35, 35, 20, 10]),
+    'default block weights should match the requested spawn percentages'
+  );
+
   context.window.Match3Config.BLOCK_TYPES[0].weight = 0;
   context.window.Match3Config.BLOCK_TYPES[1].weight = 10;
   assert.equal(logic.createRandomBlock(2), 1, 'block spawn weights should control random block generation');
-  context.window.Match3Config.BLOCK_TYPES[0].weight = 1;
-  context.window.Match3Config.BLOCK_TYPES[1].weight = 1;
+  context.window.Match3Config.BLOCK_TYPES[0].weight = 35;
+  context.window.Match3Config.BLOCK_TYPES[1].weight = 35;
 
   elements.resetButton.click();
   context.window.Match3Config.BLOCK_TYPES[0].clearSpeed = 17;
@@ -180,10 +186,16 @@ function assertBoardPanelRendered(elements, expectedSize, message) {
 
   elements.resetButton.click();
   context.window.Match3Game.state.roundStats.attack = 7;
+  context.window.Match3Game.state.roundStats.heal = 5;
   context.window.Match3Game.state.attackMultiplier = 2;
+  context.window.Match3Game.state.playerHp = 110;
   context.window.Match3Game.playerAttack();
   assert.equal(context.window.Match3Game.state.enemyHp, 136, 'player attack should apply the actual calculated damage');
+  assert.equal(context.window.Match3Game.state.playerHp, 115, 'player attack should apply accumulated healing to the hero');
+  assert.equal(context.window.Match3Game.state.damagePopups[0].target, 'enemy', 'player attack damage popup should appear over the enemy');
   assert.equal(context.window.Match3Game.state.damagePopups[0].text, '-14', 'player attack should create a damage number popup');
+  assert.equal(context.window.Match3Game.state.damagePopups[1].target, 'hero', 'healing popup should appear over the hero');
+  assert.equal(context.window.Match3Game.state.damagePopups[1].text, '+5', 'player attack should create a heal number popup');
 
   elements.resetButton.click();
   assertBoardPanelRendered(elements, 8, 'reset');

--- a/test/match3.test.js
+++ b/test/match3.test.js
@@ -178,7 +178,6 @@ function assertBoardPanelRendered(elements, expectedSize, message) {
   context.window.Match3Game.state.busy = false;
   context.window.Match3Game.state.ended = false;
   const specialActivation = context.window.Match3Game.handleCellClick({ r: 0, c: 0 });
-  await wait(1);
   assert.equal(elements.board.children[0].style['--clear-duration'], '17ms', 'per-block clear speed should be applied to clearing cells');
   await specialActivation;
   assert.ok(Number(elements.roundAttack.textContent) > 0, 'activated special blocks should accumulate cleared block effects');


### PR DESCRIPTION
### Motivation
- Align in-game feedback with player expectations by showing attack numbers over the correct target and showing real healing amounts instead of misleading or missing popups. 
- Prevent zero-value popups from appearing when damage or heal is zero. 
- Update the default spawn probabilities to the requested distribution: attack 35%, defense 35%, magic 20%, heal 10%.

### Description
- Set default `BLOCK_TYPES` weights so the first four active types use weights `35`, `35`, `20`, and `10` respectively in `assets/match3/config/block-types.js` to reflect the requested spawn distribution. 
- Change `showDamagePopup` to append popups to `state.damagePopups` so simultaneous damage/heal popups can both be shown and animated without overwriting each other. 
- In the player attack flow compute `actualHeal` from the pre- and post-HP to only show a heal popup when HP actually increased and display the real healed amount, and update the battle log to report the actual heal. 
- Only show damage popups when damage is greater than zero to avoid `-0` displays during fully blocked attacks. 
- Update unit test assertions to validate the new default weights, actual healing behavior, and popup targets in `test/match3.test.js`.

### Testing
- Ran the test suite with `npm test` (which runs `node --test`), and the test output shows the full suite passed (`match3 basic UI tests passed`).
- Verified the modified tests check default weights and popup behavior and passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3264a96fe88332a6c089f83595141a)