### PR TITLE
Add combo damage scaling and defense decay

### DIFF
--- a/assets/match3/main.js
+++ b/assets/match3/main.js
@@ -48,6 +48,15 @@
 
   function updateAttackTimer() { renderBattleStats(); }
 
+  function beginPlayerOperation() {
+    state.currentTurnCombo = 0;
+  }
+
+  function finishPlayerOperation() {
+    state.lastComboCount = state.currentTurnCombo;
+    state.currentTurnCombo = 0;
+  }
+
   function posKey(pos) { return `${pos.r},${pos.c}`; }
 
   function specialName(special) {
@@ -159,7 +168,7 @@
     const colorCount = readIntegerInput('colorCount', state.colorCount || 4, { min: 3, max: BLOCK_TYPES.length });
     const playerMaxHp = readIntegerInput('playerMaxHpInput', state.playerMaxHp || 100, { min: 1, max: 9999 });
     const enemyMaxHp = readIntegerInput('enemyMaxHpInput', state.enemyMaxHp || 100, { min: 1, max: 9999 });
-    Object.assign(state, { size, colorCount, fallSpeed: readNumberInput('fallSpeed', state.fallSpeed || 420, { min: 1, max: 5000 }), clearSpeed: readNumberInput('clearSpeed', state.clearSpeed || 260, { min: 1, max: 5000 }), attackInterval: readNumberInput('attackInterval', state.attackInterval || 5, { min: 1, max: 3600 }), enemyInterval: readNumberInput('enemyInterval', state.enemyInterval || 5, { min: 1, max: 3600 }), attackMultiplier: readNumberInput('attackMultiplier', state.attackMultiplier || 1, { min: 0, max: 999 }), defenseMultiplier: readNumberInput('defenseMultiplier', state.defenseMultiplier || 1, { min: 0, max: 999 }), enemyAttackPower: readNumberInput('enemyAttackPower', state.enemyAttackPower || 10, { min: 0, max: 9999 }), selected: null, busy: false, score: 0, moves: 30, target: size * 150, combo: 1, startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null, hint: [], playerHp: playerMaxHp, enemyHp: enemyMaxHp, playerMaxHp, enemyMaxHp, nextPlayerAttackAt: null, nextEnemyAttackAt: null, lastAction: '交換方塊後，雙方攻擊計時器會開始。', heroAction: false, enemyAction: false, ended: false, magicArmed: false });
+    Object.assign(state, { size, colorCount, fallSpeed: readNumberInput('fallSpeed', state.fallSpeed || 420, { min: 1, max: 5000 }), clearSpeed: readNumberInput('clearSpeed', state.clearSpeed || 260, { min: 1, max: 5000 }), attackInterval: readNumberInput('attackInterval', state.attackInterval || 5, { min: 1, max: 3600 }), enemyInterval: readNumberInput('enemyInterval', state.enemyInterval || 5, { min: 1, max: 3600 }), attackMultiplier: readNumberInput('attackMultiplier', state.attackMultiplier || 1, { min: 0, max: 999 }), defenseMultiplier: readNumberInput('defenseMultiplier', state.defenseMultiplier || 1, { min: 0, max: 999 }), enemyAttackPower: readNumberInput('enemyAttackPower', state.enemyAttackPower || 10, { min: 0, max: 9999 }), selected: null, busy: false, score: 0, moves: 30, target: size * 150, combo: 1, currentTurnCombo: 0, lastComboCount: 0, startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null, hint: [], playerHp: playerMaxHp, enemyHp: enemyMaxHp, playerMaxHp, enemyMaxHp, nextPlayerAttackAt: null, nextEnemyAttackAt: null, lastAction: '交換方塊後，雙方攻擊計時器會開始。', heroAction: false, enemyAction: false, ended: false, magicArmed: false });
     resetRoundStats(state);
     state.board = logic.createBoard(state.size, state.colorCount);
     renderBlockSettings();
@@ -175,9 +184,11 @@
     const clickedBlock = state.board[pos.r][pos.c];
     if (!state.selected && logic.isSpecialBlock(clickedBlock)) {
       startTimers();
+      beginPlayerOperation();
       state.busy = true;
       state.moves--;
       await activateSpecial(pos);
+      finishPlayerOperation();
       state.combo = 1;
       endTurnCheck();
       state.busy = false;
@@ -190,10 +201,12 @@
     const selectedBlock = state.board[state.selected.r][state.selected.c];
     if (logic.isSpecialBlock(selectedBlock) && logic.isSpecialBlock(clickedBlock)) {
       startTimers();
+      beginPlayerOperation();
       state.busy = true;
       state.moves--;
       await activateSpecialPair(state.selected, pos);
       state.selected = null;
+      finishPlayerOperation();
       state.combo = 1;
       endTurnCheck();
       state.busy = false;
@@ -202,6 +215,7 @@
     }
 
     startTimers();
+    beginPlayerOperation();
     state.busy = true;
     const previous = state.board;
     state.board = logic.swap(state.board, state.selected, pos);
@@ -221,6 +235,7 @@
     try {
       await resolveMatches();
       state.selected = null;
+      finishPlayerOperation();
       state.combo = 1;
       endTurnCheck();
     } catch (error) {
@@ -264,6 +279,7 @@
     state.board = collapsed.board;
     render({ fallMoves: collapsed.fallMoves, spawnMoves: collapsed.spawnMoves });
     await sleep(state.fallSpeed);
+    state.currentTurnCombo++;
     state.combo++;
   }
 

--- a/assets/match3/state/game-state.js
+++ b/assets/match3/state/game-state.js
@@ -10,6 +10,7 @@
     return {
       board: [], size: 8, colorCount: 4, fallSpeed: 420, clearSpeed: 260,
       selected: null, busy: false, score: 0, moves: 30, target: 1200, combo: 1,
+      currentTurnCombo: 0, lastComboCount: 0,
       startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null,
       hint: [], playerHp: DEFAULT_HP, enemyHp: DEFAULT_HP, playerMaxHp: DEFAULT_HP, enemyMaxHp: DEFAULT_HP,
       attackMultiplier: 1, defenseMultiplier: 1, enemyAttackPower: ENEMY_ATTACK,

--- a/assets/match3/systems/battle.js
+++ b/assets/match3/systems/battle.js
@@ -26,7 +26,8 @@
 
     function playerAttack() {
       if (state.ended) return;
-      const baseDamage = (state.roundStats.attack * state.attackMultiplier) + (state.roundStats.spell * 2);
+      const comboMultiplier = Math.pow(1.1, state.lastComboCount);
+      const baseDamage = state.roundStats.attack * comboMultiplier * state.attackMultiplier;
       const damage = state.magicArmed ? baseDamage * 2 : baseDamage;
       const heal = state.roundStats.heal;
       const playerHpBeforeHeal = state.playerHp;
@@ -35,7 +36,7 @@
       const actualHeal = state.playerHp - playerHpBeforeHeal;
       if (damage > 0) showDamagePopup('enemy', damage);
       if (actualHeal > 0) showDamagePopup('hero', actualHeal, 'heal');
-      state.lastAction = `我方攻擊造成 ${formatNumber(damage)} 傷害${state.magicArmed ? '（魔法 x2）' : ''}，回血 ${formatNumber(actualHeal)}。防禦會保留到敵方攻擊結算。`;
+      state.lastAction = `我方攻擊：攻擊方塊 ${formatNumber(state.roundStats.attack)} × 連擊倍率 1.1^${state.lastComboCount}（${formatNumber(comboMultiplier)}）× 攻擊力 ${formatNumber(state.attackMultiplier)}${state.magicArmed ? ' × 魔法 2' : ''} = ${formatNumber(damage)} 傷害，回血 ${formatNumber(actualHeal)}。防禦會保留並在敵方計時器重置時減半。`;
       state.roundStats.attack = 0;
       state.roundStats.spell = 0;
       state.roundStats.heal = 0;
@@ -47,12 +48,13 @@
 
     function enemyAttack() {
       if (state.ended) return;
-      const blocked = Math.min(state.enemyAttackPower, state.roundStats.defense * state.defenseMultiplier);
+      const defenseBeforeDecay = state.roundStats.defense;
+      const blocked = Math.min(state.enemyAttackPower, defenseBeforeDecay * state.defenseMultiplier);
       const damage = state.enemyAttackPower - blocked;
       state.playerHp = clamp(state.playerHp - damage, 0, state.playerMaxHp);
       if (damage > 0) showDamagePopup('hero', damage);
-      state.lastAction = `敵方攻擊 ${formatNumber(state.enemyAttackPower)}，防禦方塊抵擋 ${formatNumber(blocked)}，我方受到 ${formatNumber(damage)} 傷害。`;
-      resetRoundStats(state);
+      state.roundStats.defense = defenseBeforeDecay / 2;
+      state.lastAction = `敵方攻擊 ${formatNumber(state.enemyAttackPower)}，防禦方塊抵擋 ${formatNumber(blocked)}，我方受到 ${formatNumber(damage)} 傷害。防禦半衰期：${formatNumber(defenseBeforeDecay)} → ${formatNumber(state.roundStats.defense)}。`;
       state.nextEnemyAttackAt = Date.now() + sleepMsFromSeconds(state.enemyInterval);
       flashActor('enemy');
       checkBattleEnd();

--- a/assets/match3/ui/render.js
+++ b/assets/match3/ui/render.js
@@ -99,7 +99,7 @@
       $('score').textContent = state.score;
       $('moves').textContent = state.moves;
       $('target').textContent = state.target;
-      $('combo').textContent = `x${state.combo}`;
+      $('combo').textContent = `連擊 ${state.lastComboCount}（目前 x${state.combo}）`;
       $('playerHp').textContent = `${formatNumber(state.playerHp)}/${formatNumber(state.playerMaxHp)}`;
       $('enemyHp').textContent = `${formatNumber(state.enemyHp)}/${formatNumber(state.enemyMaxHp)}`;
       $('playerAttackCountdown').textContent = formatCountdown(state.nextPlayerAttackAt);

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
       <article><span>目標</span><strong id="target">1200</strong></article>
       <article><span>時間</span><strong id="timer">00:00</strong></article>
       <article><span>攻擊倒數</span><strong id="attackTimer">5.0s</strong></article>
-      <article><span>連鎖</span><strong id="combo">x1</strong></article>
+      <article><span>連擊</span><strong id="combo">連擊 0</strong></article>
       <article><span>我方血量</span><strong id="playerHp">100/100</strong></article>
       <article><span>敵方血量</span><strong id="enemyHp">100/100</strong></article>
       <article><span>我方攻擊</span><strong id="playerAttackCountdown">--</strong></article>
@@ -149,9 +149,10 @@
         </div>
         <ul>
           <li>預設方塊效果：攻擊、防禦、法術、回血。</li>
+          <li>連擊數會記錄玩家最後一次操作後，總共觸發了幾次消除。</li>
           <li>提示按鈕會標出目前可交換、且交換後能形成三消的一組相鄰方塊。</li>
-          <li>我方攻擊時間到時，消除的攻擊方塊數 × 攻擊力倍數，會變成這次對敵方造成的傷害。</li>
-          <li>敵方攻擊時間到時，消除的防禦方塊數 × 防禦力倍數，會抵消敵方攻擊。</li>
+          <li>我方攻擊時間到時，傷害 = 消除攻擊方塊數 × 1.1 的連擊數次方 × 攻擊力倍數。</li>
+          <li>敵方攻擊時間到時，防禦會抵消敵方攻擊；每次敵方計時器重置後，累積防禦會砍半。</li>
         </ul>
         <p id="battleLog" class="battle-log">尚未攻擊。</p>
         <p id="status" class="status">請交換相鄰方塊開始遊戲。</p>

--- a/test/match3.test.js
+++ b/test/match3.test.js
@@ -187,14 +187,23 @@ function assertBoardPanelRendered(elements, expectedSize, message) {
   context.window.Match3Game.state.roundStats.attack = 7;
   context.window.Match3Game.state.roundStats.heal = 5;
   context.window.Match3Game.state.attackMultiplier = 2;
+  context.window.Match3Game.state.lastComboCount = 2;
   context.window.Match3Game.state.playerHp = 110;
   context.window.Match3Game.playerAttack();
-  assert.equal(context.window.Match3Game.state.enemyHp, 136, 'player attack should apply the actual calculated damage');
+  assert.equal(context.window.Match3Game.state.enemyHp, 133.06, 'player attack should apply attack blocks times 1.1^combo times attack power');
   assert.equal(context.window.Match3Game.state.playerHp, 115, 'player attack should apply accumulated healing to the hero');
   assert.equal(context.window.Match3Game.state.damagePopups[0].target, 'enemy', 'player attack damage popup should appear over the enemy');
-  assert.equal(context.window.Match3Game.state.damagePopups[0].text, '-14', 'player attack should create a damage number popup');
+  assert.equal(context.window.Match3Game.state.damagePopups[0].text, '-16.9', 'player attack should create a damage number popup');
   assert.equal(context.window.Match3Game.state.damagePopups[1].target, 'hero', 'healing popup should appear over the hero');
   assert.equal(context.window.Match3Game.state.damagePopups[1].text, '+5', 'player attack should create a heal number popup');
+
+  elements.resetButton.click();
+  context.window.Match3Game.state.roundStats.defense = 8;
+  context.window.Match3Game.state.defenseMultiplier = 1;
+  context.window.Match3Game.state.enemyAttackPower = 12;
+  context.window.Match3Game.enemyAttack();
+  assert.equal(context.window.Match3Game.state.playerHp, 116, 'enemy attack should subtract damage after defense blocks');
+  assert.equal(context.window.Match3Game.state.roundStats.defense, 4, 'defense should be halved when the enemy timer resets');
 
   elements.resetButton.click();
   assertBoardPanelRendered(elements, 8, 'reset');


### PR DESCRIPTION
### Motivation
- Implement a "combo" / 连击 feature so damage scales with multi-wave clears from a single player operation. 
- Apply the requested damage formula using a 1.1^n multiplier where `n` is the combo count from the player's last operation. 
- Make defense decay with a half-life so accumulated defense is halved each time the enemy attack timer resolves. 

### Description
- Track combo state by adding `currentTurnCombo` and `lastComboCount` to the global state and introduce `beginPlayerOperation()` / `finishPlayerOperation()` to record the last operation's clears. 
- Increment `state.currentTurnCombo` inside `clearCells()` so each clear wave during an operation contributes to the combo. 
- Update player damage calculation in `playerAttack()` to `damage = attackBlocks * Math.pow(1.1, state.lastComboCount) * attackMultiplier` while preserving the existing magic x2 modifier and heal behavior. 
- Change enemy resolution in `enemyAttack()` to compute blocked damage from the pre-decay defense and then set `state.roundStats.defense = defenseBeforeDecay / 2` (half-life) instead of fully resetting it. 
- Update UI text and the combo display to show `lastComboCount` and reflect the new formula, and update `index.html` copy to explain combo and defense half-life rules. 
- Update test `test/match3.test.js` to assert the new numeric outcomes for player damage and defense decay. 

### Testing
- Ran `node --test` which executed the game UI unit harness and the modified assertions, and the test suite passed. 
- Ran `git diff --check` to verify no whitespace or diff issues, and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a326c3fce788332ba9c15d45eadd334)