### PR TITLE
Match-3: track per-turn combos, apply combo-based damage & defense decay, add regression checklist and redirect fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,3 +157,7 @@ Schema migrations: Drizzle Kit handles database schema changes
 Connection: Uses @neondatabase/serverless for optimized serverless connections
 Type safety: Schema definitions generate TypeScript types automatically
 The application is designed to be easily deployable to platforms like Vercel, Netlify, or Railway, with the database hosted on Neon's serverless PostgreSQL platform.
+
+Critical regression note
+- If you modify match-3 UI, HTML entry files, reset/render logic, battle stats, script tags, or element IDs, read `REGRESSION_CHECKLIST.md` and run its checks before finishing.
+- This is specifically to prevent regressions where blocks disappear or buttons stop responding.

--- a/REGRESSION_CHECKLIST.md
+++ b/REGRESSION_CHECKLIST.md
@@ -1,0 +1,15 @@
+# Match-3 Regression Checklist
+
+When changing the game UI, battle logic, or HTML entry files, always check these items before handing off work:
+
+1. Run `node --test`.
+   - This loads the scripts listed in `index.html` using the IDs that are actually present in `index.html`.
+   - It must confirm the board renders every cell, visible cells have click handlers, the hint button still works, reset still restores the board, and blank settings do not hide the board.
+2. Run `git diff --check`.
+3. Confirm `match3.html` redirects to `./index.html`, not just `./`.
+   - Redirecting to `./` can fail when the game is opened from local files and can look like the blocks/buttons disappeared.
+4. If any code touches `resetGame()`, `render()`, `renderBattleStats()`, script tags, or element IDs, re-check that:
+   - `#board` has `size × size` rendered button cells.
+   - Each visible cell has a click listener.
+   - `#hintButton`, `#resetButton`, and `#magicButton` are present and usable.
+   - Empty input values fall back to safe defaults instead of creating a blank board.

--- a/assets/match3/main.js
+++ b/assets/match3/main.js
@@ -48,6 +48,15 @@
 
   function updateAttackTimer() { renderBattleStats(); }
 
+  function beginPlayerOperation() {
+    state.currentTurnCombo = 0;
+  }
+
+  function finishPlayerOperation() {
+    state.lastComboCount = state.currentTurnCombo;
+    state.currentTurnCombo = 0;
+  }
+
   function posKey(pos) { return `${pos.r},${pos.c}`; }
 
   function specialName(special) {
@@ -159,7 +168,7 @@
     const colorCount = readIntegerInput('colorCount', state.colorCount || 4, { min: 3, max: BLOCK_TYPES.length });
     const playerMaxHp = readIntegerInput('playerMaxHpInput', state.playerMaxHp || 100, { min: 1, max: 9999 });
     const enemyMaxHp = readIntegerInput('enemyMaxHpInput', state.enemyMaxHp || 100, { min: 1, max: 9999 });
-    Object.assign(state, { size, colorCount, fallSpeed: readNumberInput('fallSpeed', state.fallSpeed || 420, { min: 1, max: 5000 }), clearSpeed: readNumberInput('clearSpeed', state.clearSpeed || 260, { min: 1, max: 5000 }), attackInterval: readNumberInput('attackInterval', state.attackInterval || 5, { min: 1, max: 3600 }), enemyInterval: readNumberInput('enemyInterval', state.enemyInterval || 5, { min: 1, max: 3600 }), attackMultiplier: readNumberInput('attackMultiplier', state.attackMultiplier || 1, { min: 0, max: 999 }), defenseMultiplier: readNumberInput('defenseMultiplier', state.defenseMultiplier || 1, { min: 0, max: 999 }), enemyAttackPower: readNumberInput('enemyAttackPower', state.enemyAttackPower || 10, { min: 0, max: 9999 }), selected: null, busy: false, score: 0, moves: 30, target: size * 150, combo: 1, startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null, hint: [], playerHp: playerMaxHp, enemyHp: enemyMaxHp, playerMaxHp, enemyMaxHp, nextPlayerAttackAt: null, nextEnemyAttackAt: null, lastAction: '交換方塊後，雙方攻擊計時器會開始。', heroAction: false, enemyAction: false, ended: false, magicArmed: false });
+    Object.assign(state, { size, colorCount, fallSpeed: readNumberInput('fallSpeed', state.fallSpeed || 420, { min: 1, max: 5000 }), clearSpeed: readNumberInput('clearSpeed', state.clearSpeed || 260, { min: 1, max: 5000 }), attackInterval: readNumberInput('attackInterval', state.attackInterval || 5, { min: 1, max: 3600 }), enemyInterval: readNumberInput('enemyInterval', state.enemyInterval || 5, { min: 1, max: 3600 }), attackMultiplier: readNumberInput('attackMultiplier', state.attackMultiplier || 1, { min: 0, max: 999 }), defenseMultiplier: readNumberInput('defenseMultiplier', state.defenseMultiplier || 1, { min: 0, max: 999 }), enemyAttackPower: readNumberInput('enemyAttackPower', state.enemyAttackPower || 10, { min: 0, max: 9999 }), selected: null, busy: false, score: 0, moves: 30, target: size * 150, combo: 1, currentTurnCombo: 0, lastComboCount: 0, startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null, hint: [], playerHp: playerMaxHp, enemyHp: enemyMaxHp, playerMaxHp, enemyMaxHp, nextPlayerAttackAt: null, nextEnemyAttackAt: null, lastAction: '交換方塊後，雙方攻擊計時器會開始。', heroAction: false, enemyAction: false, ended: false, magicArmed: false });
     resetRoundStats(state);
     state.board = logic.createBoard(state.size, state.colorCount);
     renderBlockSettings();
@@ -175,9 +184,11 @@
     const clickedBlock = state.board[pos.r][pos.c];
     if (!state.selected && logic.isSpecialBlock(clickedBlock)) {
       startTimers();
+      beginPlayerOperation();
       state.busy = true;
       state.moves--;
       await activateSpecial(pos);
+      finishPlayerOperation();
       state.combo = 1;
       endTurnCheck();
       state.busy = false;
@@ -190,10 +201,12 @@
     const selectedBlock = state.board[state.selected.r][state.selected.c];
     if (logic.isSpecialBlock(selectedBlock) && logic.isSpecialBlock(clickedBlock)) {
       startTimers();
+      beginPlayerOperation();
       state.busy = true;
       state.moves--;
       await activateSpecialPair(state.selected, pos);
       state.selected = null;
+      finishPlayerOperation();
       state.combo = 1;
       endTurnCheck();
       state.busy = false;
@@ -202,6 +215,7 @@
     }
 
     startTimers();
+    beginPlayerOperation();
     state.busy = true;
     const previous = state.board;
     state.board = logic.swap(state.board, state.selected, pos);
@@ -221,6 +235,7 @@
     try {
       await resolveMatches();
       state.selected = null;
+      finishPlayerOperation();
       state.combo = 1;
       endTurnCheck();
     } catch (error) {
@@ -264,6 +279,7 @@
     state.board = collapsed.board;
     render({ fallMoves: collapsed.fallMoves, spawnMoves: collapsed.spawnMoves });
     await sleep(state.fallSpeed);
+    state.currentTurnCombo++;
     state.combo++;
   }
 

--- a/assets/match3/state/game-state.js
+++ b/assets/match3/state/game-state.js
@@ -10,6 +10,7 @@
     return {
       board: [], size: 8, colorCount: 4, fallSpeed: 420, clearSpeed: 260,
       selected: null, busy: false, score: 0, moves: 30, target: 1200, combo: 1,
+      currentTurnCombo: 0, lastComboCount: 0,
       startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null,
       hint: [], playerHp: DEFAULT_HP, enemyHp: DEFAULT_HP, playerMaxHp: DEFAULT_HP, enemyMaxHp: DEFAULT_HP,
       attackMultiplier: 1, defenseMultiplier: 1, enemyAttackPower: ENEMY_ATTACK,

--- a/assets/match3/systems/battle.js
+++ b/assets/match3/systems/battle.js
@@ -26,7 +26,8 @@
 
     function playerAttack() {
       if (state.ended) return;
-      const baseDamage = (state.roundStats.attack * state.attackMultiplier) + (state.roundStats.spell * 2);
+      const comboMultiplier = Math.pow(1.1, state.lastComboCount);
+      const baseDamage = state.roundStats.attack * comboMultiplier * state.attackMultiplier;
       const damage = state.magicArmed ? baseDamage * 2 : baseDamage;
       const heal = state.roundStats.heal;
       const playerHpBeforeHeal = state.playerHp;
@@ -35,7 +36,7 @@
       const actualHeal = state.playerHp - playerHpBeforeHeal;
       if (damage > 0) showDamagePopup('enemy', damage);
       if (actualHeal > 0) showDamagePopup('hero', actualHeal, 'heal');
-      state.lastAction = `我方攻擊造成 ${formatNumber(damage)} 傷害${state.magicArmed ? '（魔法 x2）' : ''}，回血 ${formatNumber(actualHeal)}。防禦會保留到敵方攻擊結算。`;
+      state.lastAction = `我方攻擊：攻擊方塊 ${formatNumber(state.roundStats.attack)} × 連擊倍率 1.1^${state.lastComboCount}（${formatNumber(comboMultiplier)}）× 攻擊力 ${formatNumber(state.attackMultiplier)}${state.magicArmed ? ' × 魔法 2' : ''} = ${formatNumber(damage)} 傷害，回血 ${formatNumber(actualHeal)}。防禦會保留並在敵方計時器重置時減半。`;
       state.roundStats.attack = 0;
       state.roundStats.spell = 0;
       state.roundStats.heal = 0;
@@ -47,12 +48,13 @@
 
     function enemyAttack() {
       if (state.ended) return;
-      const blocked = Math.min(state.enemyAttackPower, state.roundStats.defense * state.defenseMultiplier);
+      const defenseBeforeDecay = state.roundStats.defense;
+      const blocked = Math.min(state.enemyAttackPower, defenseBeforeDecay * state.defenseMultiplier);
       const damage = state.enemyAttackPower - blocked;
       state.playerHp = clamp(state.playerHp - damage, 0, state.playerMaxHp);
       if (damage > 0) showDamagePopup('hero', damage);
-      state.lastAction = `敵方攻擊 ${formatNumber(state.enemyAttackPower)}，防禦方塊抵擋 ${formatNumber(blocked)}，我方受到 ${formatNumber(damage)} 傷害。`;
-      resetRoundStats(state);
+      state.roundStats.defense = defenseBeforeDecay / 2;
+      state.lastAction = `敵方攻擊 ${formatNumber(state.enemyAttackPower)}，防禦方塊抵擋 ${formatNumber(blocked)}，我方受到 ${formatNumber(damage)} 傷害。防禦半衰期：${formatNumber(defenseBeforeDecay)} → ${formatNumber(state.roundStats.defense)}。`;
       state.nextEnemyAttackAt = Date.now() + sleepMsFromSeconds(state.enemyInterval);
       flashActor('enemy');
       checkBattleEnd();

--- a/assets/match3/ui/render.js
+++ b/assets/match3/ui/render.js
@@ -99,7 +99,7 @@
       $('score').textContent = state.score;
       $('moves').textContent = state.moves;
       $('target').textContent = state.target;
-      $('combo').textContent = `x${state.combo}`;
+      $('combo').textContent = `連擊 ${state.lastComboCount}（目前 x${state.combo}）`;
       $('playerHp').textContent = `${formatNumber(state.playerHp)}/${formatNumber(state.playerMaxHp)}`;
       $('enemyHp').textContent = `${formatNumber(state.enemyHp)}/${formatNumber(state.enemyMaxHp)}`;
       $('playerAttackCountdown').textContent = formatCountdown(state.nextPlayerAttackAt);

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
       <article><span>目標</span><strong id="target">1200</strong></article>
       <article><span>時間</span><strong id="timer">00:00</strong></article>
       <article><span>攻擊倒數</span><strong id="attackTimer">5.0s</strong></article>
-      <article><span>連鎖</span><strong id="combo">x1</strong></article>
+      <article><span>連擊</span><strong id="combo">連擊 0</strong></article>
       <article><span>我方血量</span><strong id="playerHp">100/100</strong></article>
       <article><span>敵方血量</span><strong id="enemyHp">100/100</strong></article>
       <article><span>我方攻擊</span><strong id="playerAttackCountdown">--</strong></article>
@@ -149,9 +149,10 @@
         </div>
         <ul>
           <li>預設方塊效果：攻擊、防禦、法術、回血。</li>
+          <li>連擊數會記錄玩家最後一次操作後，總共觸發了幾次消除。</li>
           <li>提示按鈕會標出目前可交換、且交換後能形成三消的一組相鄰方塊。</li>
-          <li>我方攻擊時間到時，消除的攻擊方塊數 × 攻擊力倍數，會變成這次對敵方造成的傷害。</li>
-          <li>敵方攻擊時間到時，消除的防禦方塊數 × 防禦力倍數，會抵消敵方攻擊。</li>
+          <li>我方攻擊時間到時，傷害 = 消除攻擊方塊數 × 1.1 的連擊數次方 × 攻擊力倍數。</li>
+          <li>敵方攻擊時間到時，防禦會抵消敵方攻擊；每次敵方計時器重置後，累積防禦會砍半。</li>
         </ul>
         <p id="battleLog" class="battle-log">尚未攻擊。</p>
         <p id="status" class="status">請交換相鄰方塊開始遊戲。</p>

--- a/match3.html
+++ b/match3.html
@@ -2,11 +2,11 @@
 <html lang="zh-TW">
 <head>
   <meta charset="UTF-8" />
-  <meta http-equiv="refresh" content="0; url=./" />
+  <meta http-equiv="refresh" content="0; url=./index.html" />
   <title>前往 Match-3 遊戲</title>
-  <script>window.location.replace('./');</script>
+  <script>window.location.replace('./index.html');</script>
 </head>
 <body>
-  <p>正在前往遊戲首頁。如果沒有自動跳轉，請<a href="./">點這裡</a>。</p>
+  <p>正在前往遊戲首頁。如果沒有自動跳轉，請<a href="./index.html">點這裡</a>。</p>
 </body>
 </html>

--- a/test/match3.test.js
+++ b/test/match3.test.js
@@ -39,15 +39,8 @@ function createElement(id = 'created') {
 }
 
 function createHarness() {
-  const ids = [
-    'board', 'score', 'moves', 'target', 'combo', 'playerHp', 'enemyHp', 'playerAttackCountdown',
-    'enemyAttackCountdown', 'roundAttack', 'roundDefense', 'roundSpell', 'roundHeal', 'battleLog',
-    'heroSprite', 'enemySprite', 'hintButton', 'resetButton', 'playerHpText', 'enemyHpText',
-    'playerHpBar', 'enemyHpBar', 'playerAttackBar', 'enemyAttackBar', 'attackValue', 'defenseValue',
-    'magicValue', 'healValue', 'attackMeter', 'defenseMeter', 'magicMeter', 'healMeter', 'magicButton', 'timer', 'status',
-    'boardSize', 'colorCount', 'fallSpeed', 'clearSpeed', 'attackInterval', 'enemyInterval', 'attackTimer',
-    'playerMaxHpInput', 'enemyMaxHpInput', 'attackMultiplier', 'defenseMultiplier', 'enemyAttackPower', 'blockSettings'
-  ];
+  const indexHtml = fs.readFileSync('index.html', 'utf8');
+  const ids = Array.from(new Set([...indexHtml.matchAll(/\bid="([^"]+)"/g)].map(match => match[1])));
   const elements = Object.fromEntries(ids.map(id => [id, createElement(id)]));
   Object.assign(elements.boardSize, { value: '8' });
   Object.assign(elements.colorCount, { value: '4' });
@@ -83,14 +76,16 @@ function createHarness() {
   };
   context.window = context;
   vm.createContext(context);
-  [
+  const scriptFiles = [...indexHtml.matchAll(/<script src="\.\/([^"]+)"><\/script>/g)].map(match => match[1]);
+  assert.deepEqual(scriptFiles, [
     'assets/match3/config/block-types.js',
     'assets/match3/core/logic.js',
     'assets/match3/state/game-state.js',
     'assets/match3/ui/render.js',
     'assets/match3/systems/battle.js',
     'assets/match3/main.js',
-  ].forEach(file => vm.runInContext(fs.readFileSync(file, 'utf8'), context));
+  ], 'index.html should load match-3 scripts in the required order');
+  scriptFiles.forEach(file => vm.runInContext(fs.readFileSync(file, 'utf8'), context));
   return { context, elements };
 }
 
@@ -116,6 +111,10 @@ function assertBoardPanelRendered(elements, expectedSize, message) {
   assert.equal(context.window.Match3Game.showDebugOptions, false, 'debug option controls should be hidden by default');
   assert.equal(elements.blockSettings.children.length, 4, 'block settings panel should render one card per active block type');
   assert.doesNotMatch(fs.readFileSync('index.html', 'utf8'), /<details class="block-settings"[^>]*data-debug-option/, 'block settings panel should stay visible without debug options');
+
+  const redirectHtml = fs.readFileSync('match3.html', 'utf8');
+  assert.match(redirectHtml, /url=\.\/index\.html/, 'match3.html should redirect directly to index.html so the game loads from local files');
+  assert.match(redirectHtml, /window\.location\.replace\('\.\/index\.html'\)/, 'match3.html script fallback should redirect directly to index.html');
 
   elements.hintButton.click();
   assert.equal(elements.board.children.filter(cell => cell.classList.contains('hint')).length, 2, 'hint should mark one swappable pair');
@@ -187,14 +186,23 @@ function assertBoardPanelRendered(elements, expectedSize, message) {
   context.window.Match3Game.state.roundStats.attack = 7;
   context.window.Match3Game.state.roundStats.heal = 5;
   context.window.Match3Game.state.attackMultiplier = 2;
+  context.window.Match3Game.state.lastComboCount = 2;
   context.window.Match3Game.state.playerHp = 110;
   context.window.Match3Game.playerAttack();
-  assert.equal(context.window.Match3Game.state.enemyHp, 136, 'player attack should apply the actual calculated damage');
+  assert.equal(context.window.Match3Game.state.enemyHp, 133.06, 'player attack should apply attack blocks times 1.1^combo times attack power');
   assert.equal(context.window.Match3Game.state.playerHp, 115, 'player attack should apply accumulated healing to the hero');
   assert.equal(context.window.Match3Game.state.damagePopups[0].target, 'enemy', 'player attack damage popup should appear over the enemy');
-  assert.equal(context.window.Match3Game.state.damagePopups[0].text, '-14', 'player attack should create a damage number popup');
+  assert.equal(context.window.Match3Game.state.damagePopups[0].text, '-16.9', 'player attack should create a damage number popup');
   assert.equal(context.window.Match3Game.state.damagePopups[1].target, 'hero', 'healing popup should appear over the hero');
   assert.equal(context.window.Match3Game.state.damagePopups[1].text, '+5', 'player attack should create a heal number popup');
+
+  elements.resetButton.click();
+  context.window.Match3Game.state.roundStats.defense = 8;
+  context.window.Match3Game.state.defenseMultiplier = 1;
+  context.window.Match3Game.state.enemyAttackPower = 12;
+  context.window.Match3Game.enemyAttack();
+  assert.equal(context.window.Match3Game.state.playerHp, 116, 'enemy attack should subtract damage after defense blocks');
+  assert.equal(context.window.Match3Game.state.roundStats.defense, 4, 'defense should be halved when the enemy timer resets');
 
   elements.resetButton.click();
   assertBoardPanelRendered(elements, 8, 'reset');


### PR DESCRIPTION
### Motivation

- Prevent regressions that break the match-3 UI or cause blocks/buttons to disappear by adding an explicit checklist for UI/entry changes.  
- Add per-player-operation combo tracking so player damage scales with the last operation's total combo count.  
- Make defense decay explicit so accumulated defense is halved after an enemy attack interval and ensure the local redirect works for file-based opening.

### Description

- Add `currentTurnCombo` and `lastComboCount` to the game state and initialize them in `resetGame` and the state factory (`assets/match3/state/game-state.js` and `assets/match3/main.js`).
- Introduce `beginPlayerOperation` and `finishPlayerOperation` and call them around player actions and special activations so `lastComboCount` captures the combos produced by a single operation, and increment `currentTurnCombo` in `clearCells` (`assets/match3/main.js`).
- Change damage calculation in the battle system to use a combo multiplier `Math.pow(1.1, state.lastComboCount)` and adjust `playerAttack` messaging, and make `enemyAttack` halve accumulated defense after it resolves and update its message (`assets/match3/systems/battle.js`).
- Update UI text to surface the recorded last combo and the current chain multiplier and adjust help text (`assets/match3/ui/render.js` and `index.html`), and make `match3.html` redirect to `./index.html` for reliable local-file loading.
- Add `REGRESSION_CHECKLIST.md` and a critical note in `AGENTS.md` to require running checks when touching UI/entry files, and update `test/match3.test.js` to parse `index.html` for fixture IDs, assert script load order, check the redirect, and adjust expected values for the new damage/defense behavior.

### Testing

- Ran the updated unit test `test/match3.test.js` which loads `index.html` and the match-3 scripts in a VM and verifies UI rendering, hint/reset behaviors, combo/damage math, defense halving, and the `match3.html` redirect, and it passed.  
- Executed the project test command `node --test` to validate the match-3 checks listed in the new checklist, and the suite completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a326c3fce788332ba9c15d45eadd334)