### PR TITLE
Move attack countdowns to character heads, smooth timers, and remove target score

### DIFF
--- a/assets/match3.css
+++ b/assets/match3.css
@@ -52,7 +52,7 @@ button:disabled { opacity: .55; cursor: not-allowed; }
 .fighter-card.enemy .fighter-avatar { background: linear-gradient(135deg, #fb7185, #be123c); }
 .attack-countdown { display: grid; gap: 6px; color: #64748b; font-weight: 800; }
 .bar { height: 12px; overflow: hidden; border-radius: 999px; background: #e2e8f0; box-shadow: inset 0 1px 2px rgba(15,23,42,.12); }
-.bar span { display: block; width: 0%; height: 100%; border-radius: inherit; background: linear-gradient(90deg, #38bdf8, #2563eb); transition: width 120ms linear; }
+.bar span { display: block; width: 0%; height: 100%; border-radius: inherit; background: linear-gradient(90deg, #38bdf8, #2563eb); transition: width 180ms linear; }
 .bar.hp span { width: 100%; background: linear-gradient(90deg, #34d399, #16a34a); }
 .game-layout { grid-template-columns: 190px max-content minmax(240px, 1fr); }
 .accumulation-panel { padding: 16px; }
@@ -66,11 +66,16 @@ button:disabled { opacity: .55; cursor: not-allowed; }
 #healMeter { background: linear-gradient(90deg, #86efac, #16a34a); }
 .magic-button { width: 100%; min-height: 44px; margin-top: 6px; background: #7c3aed; }
 .meter-note { margin-bottom: 0; color: #64748b; font-size: 13px; line-height: 1.5; }
-.stats { grid-template-columns: repeat(9, minmax(96px, 1fr)); }
+.stats { grid-template-columns: repeat(7, minmax(96px, 1fr)); }
 .cell { position: relative; display: grid; place-items: center; font-size: 22px; text-shadow: 0 2px 0 rgba(0,0,0,.18); }
 .cell-icon { pointer-events: none; filter: drop-shadow(0 2px 0 rgba(255,255,255,.22)); }
 .battle-stage { display: grid; grid-template-columns: 1fr auto 1fr; align-items: end; gap: 12px; padding: 16px; margin-bottom: 14px; border-radius: 16px; background: linear-gradient(#dbeafe, #f8fafc); border: 2px solid rgba(59,130,246,.18); }
 .fighter { display: grid; justify-items: center; gap: 8px; font-weight: 800; }
+.stage-countdown { width: 112px; padding: 8px 10px; border-radius: 999px; background: rgba(255,255,255,.92); border: 1px solid rgba(148,163,184,.45); box-shadow: 0 10px 22px rgba(15,23,42,.12); text-align: center; color: #1d4ed8; }
+.stage-countdown strong { display: block; margin-bottom: 5px; font-size: 18px; line-height: 1; }
+.stage-countdown .bar { height: 8px; }
+.enemy-fighter .stage-countdown { color: #be123c; }
+.enemy-fighter .stage-countdown .bar span { background: linear-gradient(90deg, #fb7185, #be123c); }
 .versus { align-self: center; color: #ef4444; font-weight: 900; letter-spacing: .08em; }
 .pixel-sprite { position: relative; width: 54px; height: 72px; image-rendering: pixelated; animation: idle-bob 900ms steps(2, end) infinite; }
 .pixel-sprite::before { content: ''; position: absolute; left: 17px; top: 4px; width: 20px; height: 20px; background: #f8c38a; box-shadow: 0 20px 0 #2563eb, -10px 28px 0 #1d4ed8, 10px 28px 0 #1d4ed8, -8px 48px 0 #334155, 8px 48px 0 #334155, 0 -6px 0 #7c2d12; }

--- a/assets/match3/main.js
+++ b/assets/match3/main.js
@@ -30,9 +30,9 @@
     return Math.round(readNumberInput(id, fallback, range));
   }
 
-  function formatCountdown(target) {
-    if (!target || state.ended) return '--';
-    return `${Math.max(0, Math.ceil((target - Date.now()) / 1000))}s`;
+  function formatCountdown(target, fallbackSeconds = null) {
+    if (!target || state.ended) return fallbackSeconds === null ? '--' : `${Number(fallbackSeconds).toFixed(1)}s`;
+    return `${Math.max(0, (target - Date.now()) / 1000).toFixed(1)}s`;
   }
   function countdownProgress(target, intervalSeconds) {
     if (!target || state.ended) return 0;
@@ -143,8 +143,8 @@
     if (!state.startedAt) { $('timer').textContent = '00:00'; return; }
     const sec = Math.floor((Date.now() - state.startedAt) / 1000);
     $('timer').textContent = `${String(Math.floor(sec / 60)).padStart(2, '0')}:${String(sec % 60).padStart(2, '0')}`;
-    $('playerAttackCountdown').textContent = formatCountdown(state.nextPlayerAttackAt);
-    $('enemyAttackCountdown').textContent = formatCountdown(state.nextEnemyAttackAt);
+    $('playerAttackCountdown').textContent = formatCountdown(state.nextPlayerAttackAt, state.attackInterval);
+    $('enemyAttackCountdown').textContent = formatCountdown(state.nextEnemyAttackAt, state.enemyInterval);
     renderBattleStats();
   }
 
@@ -153,7 +153,7 @@
     state.startedAt = Date.now();
     state.nextPlayerAttackAt = Date.now() + sleepMsFromSeconds(state.attackInterval);
     state.nextEnemyAttackAt = Date.now() + sleepMsFromSeconds(state.enemyInterval);
-    state.timerId = setInterval(updateTimer, 1000);
+    state.timerId = setInterval(updateTimer, 100);
     state.attackTimerId = setInterval(playerAttack, sleepMsFromSeconds(state.attackInterval));
     state.enemyTimerId = setInterval(enemyAttack, sleepMsFromSeconds(state.enemyInterval));
   }
@@ -168,7 +168,7 @@
     const colorCount = readIntegerInput('colorCount', state.colorCount || 4, { min: 3, max: BLOCK_TYPES.length });
     const playerMaxHp = readIntegerInput('playerMaxHpInput', state.playerMaxHp || 100, { min: 1, max: 9999 });
     const enemyMaxHp = readIntegerInput('enemyMaxHpInput', state.enemyMaxHp || 100, { min: 1, max: 9999 });
-    Object.assign(state, { size, colorCount, fallSpeed: readNumberInput('fallSpeed', state.fallSpeed || 420, { min: 1, max: 5000 }), clearSpeed: readNumberInput('clearSpeed', state.clearSpeed || 260, { min: 1, max: 5000 }), attackInterval: readNumberInput('attackInterval', state.attackInterval || 5, { min: 1, max: 3600 }), enemyInterval: readNumberInput('enemyInterval', state.enemyInterval || 5, { min: 1, max: 3600 }), attackMultiplier: readNumberInput('attackMultiplier', state.attackMultiplier || 1, { min: 0, max: 999 }), defenseMultiplier: readNumberInput('defenseMultiplier', state.defenseMultiplier || 1, { min: 0, max: 999 }), enemyAttackPower: readNumberInput('enemyAttackPower', state.enemyAttackPower || 10, { min: 0, max: 9999 }), selected: null, busy: false, score: 0, moves: 30, target: size * 150, combo: 1, currentTurnCombo: 0, lastComboCount: 0, startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null, hint: [], playerHp: playerMaxHp, enemyHp: enemyMaxHp, playerMaxHp, enemyMaxHp, nextPlayerAttackAt: null, nextEnemyAttackAt: null, lastAction: '交換方塊後，雙方攻擊計時器會開始。', heroAction: false, enemyAction: false, ended: false, magicArmed: false });
+    Object.assign(state, { size, colorCount, fallSpeed: readNumberInput('fallSpeed', state.fallSpeed || 420, { min: 1, max: 5000 }), clearSpeed: readNumberInput('clearSpeed', state.clearSpeed || 260, { min: 1, max: 5000 }), attackInterval: readNumberInput('attackInterval', state.attackInterval || 5, { min: 1, max: 3600 }), enemyInterval: readNumberInput('enemyInterval', state.enemyInterval || 5, { min: 1, max: 3600 }), attackMultiplier: readNumberInput('attackMultiplier', state.attackMultiplier || 1, { min: 0, max: 999 }), defenseMultiplier: readNumberInput('defenseMultiplier', state.defenseMultiplier || 1, { min: 0, max: 999 }), enemyAttackPower: readNumberInput('enemyAttackPower', state.enemyAttackPower || 10, { min: 0, max: 9999 }), selected: null, busy: false, score: 0, moves: 30, combo: 1, currentTurnCombo: 0, lastComboCount: 0, startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null, hint: [], playerHp: playerMaxHp, enemyHp: enemyMaxHp, playerMaxHp, enemyMaxHp, nextPlayerAttackAt: null, nextEnemyAttackAt: null, lastAction: '交換方塊後，雙方攻擊計時器會開始。', heroAction: false, enemyAction: false, ended: false, magicArmed: false });
     resetRoundStats(state);
     state.board = logic.createBoard(state.size, state.colorCount);
     renderBlockSettings();
@@ -337,7 +337,6 @@
 
   function endTurnCheck() {
     if (state.ended) return;
-    if (state.score >= state.target) { setStatus('恭喜達成目標分數，也可以繼續打倒敵人。'); return; }
     if (state.moves <= 0) { setStatus('步數用完，請重設再挑戰一次。'); return; }
     if (!logic.findAvailableMove(state.board)) {
       state.board = logic.shuffleBoard(state.board);

--- a/assets/match3/state/game-state.js
+++ b/assets/match3/state/game-state.js
@@ -9,7 +9,7 @@
   function createState() {
     return {
       board: [], size: 8, colorCount: 4, fallSpeed: 420, clearSpeed: 260,
-      selected: null, busy: false, score: 0, moves: 30, target: 1200, combo: 1,
+      selected: null, busy: false, score: 0, moves: 30, combo: 1,
       currentTurnCombo: 0, lastComboCount: 0,
       startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null,
       hint: [], playerHp: DEFAULT_HP, enemyHp: DEFAULT_HP, playerMaxHp: DEFAULT_HP, enemyMaxHp: DEFAULT_HP,

--- a/assets/match3/ui/render.js
+++ b/assets/match3/ui/render.js
@@ -21,13 +21,18 @@
       const defenseMeterMax = Math.max(100, state.enemyAttackPower);
       const healMeterMax = Math.max(100, state.playerMaxHp - state.playerHp);
 
-      $('attackTimer').textContent = formatCountdown(state.nextPlayerAttackAt) === '--' ? `${state.attackInterval}.0s` : formatCountdown(state.nextPlayerAttackAt);
+      const playerCountdown = formatCountdown(state.nextPlayerAttackAt, state.attackInterval);
+      const enemyCountdown = formatCountdown(state.nextEnemyAttackAt, state.enemyInterval);
       $('playerHpText').textContent = `${formatNumber(state.playerHp)} / ${formatNumber(state.playerMaxHp)}`;
       $('enemyHpText').textContent = `${formatNumber(state.enemyHp)} / ${formatNumber(state.enemyMaxHp)}`;
       setBar('playerHpBar', state.playerHp, state.playerMaxHp);
       setBar('enemyHpBar', state.enemyHp, state.enemyMaxHp);
       setBar('playerAttackBar', countdownProgress(state.nextPlayerAttackAt, state.attackInterval));
       setBar('enemyAttackBar', countdownProgress(state.nextEnemyAttackAt, state.enemyInterval));
+      $('playerStageAttackCountdown').textContent = playerCountdown;
+      $('enemyStageAttackCountdown').textContent = enemyCountdown;
+      setBar('playerStageAttackBar', countdownProgress(state.nextPlayerAttackAt, state.attackInterval));
+      setBar('enemyStageAttackBar', countdownProgress(state.nextEnemyAttackAt, state.enemyInterval));
       $('attackValue').textContent = `${formatNumber(attack)} / ${formatNumber(attackMeterMax)}`;
       $('defenseValue').textContent = `${formatNumber(defense)} / ${formatNumber(defenseMeterMax)}`;
       $('magicValue').textContent = `${formatNumber(clamp(magic, 0, 100))} / 100`;
@@ -98,12 +103,11 @@
 
       $('score').textContent = state.score;
       $('moves').textContent = state.moves;
-      $('target').textContent = state.target;
       $('combo').textContent = `連擊 ${state.lastComboCount}（目前 x${state.combo}）`;
       $('playerHp').textContent = `${formatNumber(state.playerHp)}/${formatNumber(state.playerMaxHp)}`;
       $('enemyHp').textContent = `${formatNumber(state.enemyHp)}/${formatNumber(state.enemyMaxHp)}`;
-      $('playerAttackCountdown').textContent = formatCountdown(state.nextPlayerAttackAt);
-      $('enemyAttackCountdown').textContent = formatCountdown(state.nextEnemyAttackAt);
+      $('playerAttackCountdown').textContent = formatCountdown(state.nextPlayerAttackAt, state.attackInterval);
+      $('enemyAttackCountdown').textContent = formatCountdown(state.nextEnemyAttackAt, state.enemyInterval);
       $('roundAttack').textContent = state.roundStats.attack;
       $('roundDefense').textContent = state.roundStats.defense;
       $('roundSpell').textContent = state.roundStats.spell;

--- a/index.html
+++ b/index.html
@@ -70,9 +70,7 @@
     <section class="stats" aria-label="遊戲狀態">
       <article><span>分數</span><strong id="score">0</strong></article>
       <article><span>步數</span><strong id="moves">30</strong></article>
-      <article><span>目標</span><strong id="target">1200</strong></article>
       <article><span>時間</span><strong id="timer">00:00</strong></article>
-      <article><span>攻擊倒數</span><strong id="attackTimer">5.0s</strong></article>
       <article><span>連擊</span><strong id="combo">連擊 0</strong></article>
       <article><span>我方血量</span><strong id="playerHp">100/100</strong></article>
       <article><span>敵方血量</span><strong id="enemyHp">100/100</strong></article>
@@ -132,11 +130,19 @@
         <h2>戰鬥狀態</h2>
         <div class="battle-stage" aria-label="角色戰鬥展示">
           <div class="fighter hero-fighter">
+            <div class="stage-countdown" aria-label="我方下次攻擊倒數">
+              <strong id="playerStageAttackCountdown">--</strong>
+              <div class="bar"><span id="playerStageAttackBar"></span></div>
+            </div>
             <div id="heroSprite" class="pixel-sprite hero-sprite" aria-label="我方像素角色"></div>
             <strong>我方</strong>
           </div>
           <div class="versus">VS</div>
           <div class="fighter enemy-fighter">
+            <div class="stage-countdown" aria-label="敵方下次攻擊倒數">
+              <strong id="enemyStageAttackCountdown">--</strong>
+              <div class="bar"><span id="enemyStageAttackBar"></span></div>
+            </div>
             <div id="enemySprite" class="pixel-sprite enemy-sprite" aria-label="敵方像素角色"></div>
             <strong>敵方</strong>
           </div>

--- a/test/match3.test.js
+++ b/test/match3.test.js
@@ -214,7 +214,7 @@ function assertBoardPanelRendered(elements, expectedSize, message) {
   elements.clearSpeed.value = '';
   elements.resetButton.click();
   assertBoardPanelRendered(elements, 8, 'reset with blank settings');
-  assert.equal(elements.target.textContent, 1200, 'blank board size should fall back without hiding the board');
+  assert.ok(!('target' in elements), 'target score card should not be rendered because it is no longer used');
 
   console.log('match3 basic UI tests passed');
 })().catch(error => {


### PR DESCRIPTION
### Motivation
- Improve UX by placing the active attack countdown visual directly above each character and make the countdown smoother (more granular) for clearer feedback. 
- Remove the unused target/goal score from UI and state since it is not used by gameplay. 
- Keep the codebase ready for future work around adding characters/enemies by making the attack-timer visuals and timing logic clearer.

### Description
- Moved per-actor countdown UI into the battle stage and added compact `stage-countdown` bars above `heroSprite` and `enemySprite` in `index.html` (`playerStageAttackCountdown`, `playerStageAttackBar`, `enemyStageAttackCountdown`, `enemyStageAttackBar`).
- Reworked renderer to produce stage-head countdowns and progress bars by adding `playerCountdown`/`enemyCountdown` and wiring `playerStageAttackCountdown`/`enemyStageAttackCountdown` and their bars in `assets/match3/ui/render.js`.
- Made countdown display show one decimal place and return a fallback formatted value when no active target is set by changing `formatCountdown` signature and behavior in `assets/match3/main.js` and used it throughout render/update code.
- Increased the timer refresh rate to update the UI more smoothly by changing the `updateTimer` interval to run every `100ms` in `assets/match3/main.js` and adjusted the countdown progress and bar transitions for smoother animation (CSS `.bar span` transition increased; new `.stage-countdown` styles added) in `assets/match3.css`.
- Removed the unused `target` UI element and related state/logic: `target` card removed from `index.html`, `target` property removed from `assets/match3/state/game-state.js`, and the end-turn check that referenced `state.target` removed from `assets/match3/main.js` and renderer updates that set the `#target` element were dropped from `assets/match3/ui/render.js`.
- Updated test expectations in `test/match3.test.js` to reflect that the target score element is no longer present.

### Testing
- Ran unit/UI integration harness with `node --test`, which passed (`match3 basic UI tests passed`).
- Ran `git diff --check`/lint-style checks to ensure no whitespace/diff errors and there were none reported.
- Attempted a Playwright screenshot to visually verify layout, but the environment lacks the `playwright` package so the screenshot step could not run (dependency not installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a334b68b8608332a97aa41c1be44b45)