### PR TITLE
Refactor battle UI: consolidate meters, update layout and renderer

### DIFF
--- a/assets/match3.css
+++ b/assets/match3.css
@@ -54,26 +54,24 @@ button:disabled { opacity: .55; cursor: not-allowed; }
 .bar { height: 12px; overflow: hidden; border-radius: 999px; background: #e2e8f0; box-shadow: inset 0 1px 2px rgba(15,23,42,.12); }
 .bar span { display: block; width: 0%; height: 100%; border-radius: inherit; background: linear-gradient(90deg, #38bdf8, #2563eb); transition: width 180ms linear; }
 .bar.hp span { width: 100%; background: linear-gradient(90deg, #34d399, #16a34a); }
-.game-layout { grid-template-columns: 190px max-content minmax(240px, 1fr); }
-.accumulation-panel { padding: 16px; }
-.accumulation-panel h2 { margin-top: 0; }
-.meter-row { display: grid; gap: 6px; margin-bottom: 14px; }
-.meter-row span { color: #64748b; font-weight: 800; }
-.meter-row strong { font-size: 18px; }
+.game-layout { grid-template-columns: max-content minmax(360px, 1fr); }
 #attackMeter { background: linear-gradient(90deg, #fb923c, #ef4444); }
 #defenseMeter { background: linear-gradient(90deg, #93c5fd, #2563eb); }
 #magicMeter { background: linear-gradient(90deg, #c084fc, #7c3aed); }
 #healMeter { background: linear-gradient(90deg, #86efac, #16a34a); }
-.magic-button { width: 100%; min-height: 44px; margin-top: 6px; background: #7c3aed; }
+.magic-button { width: 100%; min-height: 34px; margin-top: 0; padding: 0 10px; background: #7c3aed; font-size: 12px; }
 .meter-note { margin-bottom: 0; color: #64748b; font-size: 13px; line-height: 1.5; }
 .stats { grid-template-columns: repeat(7, minmax(96px, 1fr)); }
 .cell { position: relative; display: grid; place-items: center; font-size: 22px; text-shadow: 0 2px 0 rgba(0,0,0,.18); }
 .cell-icon { pointer-events: none; filter: drop-shadow(0 2px 0 rgba(255,255,255,.22)); }
 .battle-stage { display: grid; grid-template-columns: 1fr auto 1fr; align-items: end; gap: 12px; padding: 16px; margin-bottom: 14px; border-radius: 16px; background: linear-gradient(#dbeafe, #f8fafc); border: 2px solid rgba(59,130,246,.18); }
 .fighter { display: grid; justify-items: center; gap: 8px; font-weight: 800; }
-.stage-countdown { width: 112px; padding: 8px 10px; border-radius: 999px; background: rgba(255,255,255,.92); border: 1px solid rgba(148,163,184,.45); box-shadow: 0 10px 22px rgba(15,23,42,.12); text-align: center; color: #1d4ed8; }
-.stage-countdown strong { display: block; margin-bottom: 5px; font-size: 18px; line-height: 1; }
+.stage-hp, .stage-countdown { width: 128px; padding: 8px 10px; border-radius: 14px; background: rgba(255,255,255,.92); border: 1px solid rgba(148,163,184,.45); box-shadow: 0 10px 22px rgba(15,23,42,.12); text-align: center; color: #1d4ed8; }
+.stage-hp { color: #15803d; }
+.stage-countdown span { display: block; margin-bottom: 2px; color: #64748b; font-size: 11px; line-height: 1; }
+.stage-hp strong, .stage-countdown strong { display: block; margin-bottom: 5px; font-size: 16px; line-height: 1; }
 .stage-countdown .bar { height: 8px; }
+.stage-hp .bar { height: 8px; }
 .enemy-fighter .stage-countdown { color: #be123c; }
 .enemy-fighter .stage-countdown .bar span { background: linear-gradient(90deg, #fb7185, #be123c); }
 .versus { align-self: center; color: #ef4444; font-weight: 900; letter-spacing: .08em; }
@@ -84,6 +82,11 @@ button:disabled { opacity: .55; cursor: not-allowed; }
 .hero-sprite.attacking { animation: hero-attack 520ms steps(3, end); }
 .enemy-sprite.attacking { animation: enemy-attack 520ms steps(3, end); }
 .hero-sprite.attacking::after, .enemy-sprite.attacking::after { transform: rotate(-55deg); }
+.stage-meters { grid-column: 1 / -1; display: grid; grid-template-columns: repeat(4, minmax(86px, 1fr)) minmax(120px, .8fr); gap: 8px; align-items: stretch; padding: 8px; border-radius: 14px; background: rgba(255,255,255,.72); border: 1px solid rgba(148,163,184,.35); }
+.mini-meter { display: grid; gap: 4px; min-width: 0; padding: 8px; border-radius: 12px; background: rgba(248,250,252,.92); border: 1px solid #e2e8f0; }
+.mini-meter span { color: #64748b; font-size: 12px; font-weight: 900; }
+.mini-meter strong { font-size: 13px; line-height: 1; }
+.mini-meter .bar { height: 7px; }
 .effect-grid { display: grid; grid-template-columns: repeat(2, minmax(120px, 1fr)); gap: 8px; margin-bottom: 12px; }
 .effect-grid span, .battle-log { border-radius: 12px; background: #f8fafc; border: 1px solid #e2e8f0; padding: 10px; font-weight: 700; }
 .battle-log { color: #7c2d12; background: #fff7ed; }
@@ -92,7 +95,7 @@ button:disabled { opacity: .55; cursor: not-allowed; }
 @keyframes hero-attack { 50% { transform: translateX(18px); } }
 @keyframes enemy-attack { 0%, 100% { transform: scaleX(-1) translateX(0); } 50% { transform: scaleX(-1) translateX(18px); } }
 @media (max-width: 980px) { .stats { grid-template-columns: repeat(3, 1fr); } }
-@media (max-width: 820px) { .battle-panel, .game-layout { grid-template-columns: 1fr; } .accumulation-panel { order: -1; } .stats { grid-template-columns: repeat(2, 1fr); } .effect-grid { grid-template-columns: 1fr; } }
+@media (max-width: 820px) { .battle-panel, .game-layout { grid-template-columns: 1fr; } .stats { grid-template-columns: repeat(2, 1fr); } .effect-grid { grid-template-columns: 1fr; } .stage-meters { grid-template-columns: repeat(2, minmax(120px, 1fr)); } .magic-button { grid-column: 1 / -1; } }
 
 .cell.special { border-color: #fff7ed; box-shadow: inset 0 -7px 0 rgba(0,0,0,.12), 0 0 0 3px rgba(250,204,21,.8), 0 10px 18px rgba(15,23,42,.22); overflow: hidden; }
 .cell.special::before { content: ''; position: absolute; inset: -35%; background: conic-gradient(from 0deg, transparent, rgba(255,255,255,.72), transparent 32%); animation: special-spin 1.8s linear infinite; }

--- a/assets/match3/ui/render.js
+++ b/assets/match3/ui/render.js
@@ -27,8 +27,6 @@
       $('enemyHpText').textContent = `${formatNumber(state.enemyHp)} / ${formatNumber(state.enemyMaxHp)}`;
       setBar('playerHpBar', state.playerHp, state.playerMaxHp);
       setBar('enemyHpBar', state.enemyHp, state.enemyMaxHp);
-      setBar('playerAttackBar', countdownProgress(state.nextPlayerAttackAt, state.attackInterval));
-      setBar('enemyAttackBar', countdownProgress(state.nextEnemyAttackAt, state.enemyInterval));
       $('playerStageAttackCountdown').textContent = playerCountdown;
       $('enemyStageAttackCountdown').textContent = enemyCountdown;
       setBar('playerStageAttackBar', countdownProgress(state.nextPlayerAttackAt, state.attackInterval));

--- a/index.html
+++ b/index.html
@@ -78,73 +78,60 @@
       <article><span>敵方攻擊</span><strong id="enemyAttackCountdown">--</strong></article>
     </section>
 
-    <section class="battle-panel" aria-label="戰鬥狀態">
-      <article class="fighter-card">
-        <div class="attack-countdown">
-          <span>下次攻擊</span>
-          <div class="bar"><span id="playerAttackBar"></span></div>
-        </div>
-        <div class="fighter-avatar">勇者</div>
-        <strong id="playerHpText">100 / 100</strong>
-        <div class="bar hp"><span id="playerHpBar"></span></div>
-      </article>
-      <article class="fighter-card enemy">
-        <div class="attack-countdown">
-          <span>下次攻擊</span>
-          <div class="bar"><span id="enemyAttackBar"></span></div>
-        </div>
-        <div class="fighter-avatar">魔王</div>
-        <strong id="enemyHpText">100 / 100</strong>
-        <div class="bar hp"><span id="enemyHpBar"></span></div>
-      </article>
-    </section>
-
     <section class="game-layout">
-      <aside class="panel accumulation-panel" aria-label="累積戰鬥效果">
-        <h2>累積效果</h2>
-        <div class="meter-row">
-          <span>攻擊</span>
-          <strong id="attackValue">0 / 100</strong>
-          <div class="bar"><span id="attackMeter"></span></div>
-        </div>
-        <div class="meter-row">
-          <span>防禦</span>
-          <strong id="defenseValue">0 / 100</strong>
-          <div class="bar"><span id="defenseMeter"></span></div>
-        </div>
-        <div class="meter-row">
-          <span>魔法</span>
-          <strong id="magicValue">0 / 100</strong>
-          <div class="bar"><span id="magicMeter"></span></div>
-        </div>
-        <div class="meter-row">
-          <span>回血</span>
-          <strong id="healValue">0 / 100</strong>
-          <div class="bar"><span id="healMeter"></span></div>
-        </div>
-        <button id="magicButton" type="button" class="magic-button">使用魔法（下次攻擊 x2）</button>
-        <p class="meter-note">魔法每 50 點可使用 1 次，最多累積 2 次。</p>
-      </aside>
       <div id="board" class="board" aria-label="三消遊戲棋盤"></div>
       <aside class="panel business-panel">
         <h2>戰鬥狀態</h2>
         <div class="battle-stage" aria-label="角色戰鬥展示">
           <div class="fighter hero-fighter">
-            <div class="stage-countdown" aria-label="我方下次攻擊倒數">
-              <strong id="playerStageAttackCountdown">--</strong>
-              <div class="bar"><span id="playerStageAttackBar"></span></div>
+            <div class="stage-hp" aria-label="我方血量">
+              <strong id="playerHpText">100 / 100</strong>
+              <div class="bar hp"><span id="playerHpBar"></span></div>
             </div>
             <div id="heroSprite" class="pixel-sprite hero-sprite" aria-label="我方像素角色"></div>
             <strong>我方</strong>
+            <div class="stage-countdown" aria-label="我方下次攻擊倒數">
+              <span>下次攻擊</span>
+              <strong id="playerStageAttackCountdown">--</strong>
+              <div class="bar"><span id="playerStageAttackBar"></span></div>
+            </div>
           </div>
           <div class="versus">VS</div>
           <div class="fighter enemy-fighter">
-            <div class="stage-countdown" aria-label="敵方下次攻擊倒數">
-              <strong id="enemyStageAttackCountdown">--</strong>
-              <div class="bar"><span id="enemyStageAttackBar"></span></div>
+            <div class="stage-hp" aria-label="敵方血量">
+              <strong id="enemyHpText">100 / 100</strong>
+              <div class="bar hp"><span id="enemyHpBar"></span></div>
             </div>
             <div id="enemySprite" class="pixel-sprite enemy-sprite" aria-label="敵方像素角色"></div>
             <strong>敵方</strong>
+            <div class="stage-countdown" aria-label="敵方下次攻擊倒數">
+              <span>下次攻擊</span>
+              <strong id="enemyStageAttackCountdown">--</strong>
+              <div class="bar"><span id="enemyStageAttackBar"></span></div>
+            </div>
+          </div>
+          <div class="stage-meters" aria-label="累積戰鬥效果">
+            <div class="mini-meter">
+              <span>⚔ 攻擊</span>
+              <strong id="attackValue">0 / 100</strong>
+              <div class="bar"><span id="attackMeter"></span></div>
+            </div>
+            <div class="mini-meter">
+              <span>🛡 防禦</span>
+              <strong id="defenseValue">0 / 100</strong>
+              <div class="bar"><span id="defenseMeter"></span></div>
+            </div>
+            <div class="mini-meter">
+              <span>✦ 魔法</span>
+              <strong id="magicValue">0 / 100</strong>
+              <div class="bar"><span id="magicMeter"></span></div>
+            </div>
+            <div class="mini-meter">
+              <span>❤ 回血</span>
+              <strong id="healValue">0 / 100</strong>
+              <div class="bar"><span id="healMeter"></span></div>
+            </div>
+            <button id="magicButton" type="button" class="magic-button">使用魔法（下次攻擊 x2）</button>
           </div>
         </div>
         <div class="effect-grid" aria-label="本輪累積效果">


### PR DESCRIPTION
### Motivation

- Combine separate battle and accumulation panels into a single, compact battle UI to improve layout and readability.
- Make meters and countdowns more consistent and responsive across screen sizes and reduce visual clutter for smaller screens. 

### Description

- Reworked HTML to remove the standalone `battle-panel` and `accumulation-panel`, embedding health, sprites, countdowns and compact meters into the main `battle-stage` (`stage-hp`, `stage-countdown`, `stage-meters`, `mini-meter`) and moved the `magicButton` into the new meter area. 
- Updated CSS (`assets/match3.css`) to adjust `.game-layout` grid columns, introduce `.stage-meters`, `.mini-meter`, `.stage-hp`, tighten `.magic-button` styling, tweak countdown/HP card styles, and add responsive rules for mobile. 
- Updated renderer (`assets/match3/ui/render.js`) to stop writing to the removed `playerAttackBar`/`enemyAttackBar` elements and instead use the stage attack bars (`playerStageAttackBar` / `enemyStageAttackBar`) and to keep meter/HP updates aligned with the restructured DOM. 

### Testing

- Ran linter via `npm run lint` and it completed successfully. 
- Performed a project build with `npm run build` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a334e4536e083328f88e35bda44581f)