### PR TITLE
Add roguelite route progression

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,9 @@
 
 This is a basic match-3 puzzle game. You can change how many colors appear, how big the board is, and how fast blocks fall and clear. If there are no more matches, the board shuffles itself. Open `match3.html` in your browser to play. 
 test mr
+
+## Baseline Snapshot Before Roguelite Layer
+
+- Baseline commit before this roguelite/layered progression work: `3c9e368bcf444829c34d08ac6a49ffde2040dc48`.
+- At that point, the game was a single match-3 battle: players swap adjacent blocks, clear 3+ connected same-colored blocks, build attack/defense/spell/heal values, and fight one enemy using timed player/enemy attacks.
+- Existing safety checks live in `REGRESSION_CHECKLIST.md`; keep using them when changing UI, reset/render logic, battle stats, script tags, or element IDs.

--- a/assets/match3.css
+++ b/assets/match3.css
@@ -120,3 +120,13 @@ button:disabled { opacity: .55; cursor: not-allowed; }
   to { opacity: 0; transform: translate(-50%, -34px) scale(1); }
 }
 .fighter { position: relative; }
+.run-panel { margin-bottom: 16px; padding: 16px; }
+.run-panel h2 { margin: 0 0 10px; }
+.route-list { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 10px; }
+.route-node { padding: 8px 10px; border-radius: 999px; background: #e2e8f0; color: #475569; font-weight: 800; }
+.route-node.current { background: #fef3c7; color: #92400e; box-shadow: 0 0 0 3px rgba(250,204,21,.35); }
+.route-node.done { background: #dcfce7; color: #166534; }
+.gear-list { display: flex; flex-wrap: wrap; gap: 8px 16px; padding-left: 18px; }
+.run-actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
+.run-actions button { background: #7c3aed; }
+.run-actions button[data-next-node] { background: #2563eb; }

--- a/assets/match3/main.js
+++ b/assets/match3/main.js
@@ -18,6 +18,52 @@
   function sleep(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }
   function sleepMsFromSeconds(seconds) { return Math.max(1, Number(seconds)) * 1000; }
   function formatNumber(value) { return Number.isInteger(value) ? String(value) : value.toFixed(1); }
+  function pick(items) { return items[Math.floor(Math.random() * items.length)]; }
+
+  const ENEMY_POOL = [
+    { name: '史萊姆', hp: 70, attack: 8 },
+    { name: '骷髏兵', hp: 90, attack: 11 },
+    { name: '火焰小鬼', hp: 80, attack: 14 },
+    { name: '石像守衛', hp: 115, attack: 10 },
+  ];
+  const EQUIPMENT_SHOP = [
+    { slot: 'weapon', name: '鐵劍', attack: 0.4, price: 20 },
+    { slot: 'armor', name: '鎖子甲', defense: 0.5, price: 20 },
+    { slot: 'charm', name: '生命護符', hp: 25, price: 18 },
+  ];
+
+  function equipmentTotals() {
+    return Object.values(state.run.equipment).reduce((total, item) => ({
+      hp: total.hp + (item.hp || 0),
+      attack: total.attack + (item.attack || 0),
+      defense: total.defense + (item.defense || 0),
+    }), { hp: 0, attack: 0, defense: 0 });
+  }
+
+  function heroDerivedStats() {
+    const gear = equipmentTotals();
+    return {
+      maxHp: 100 + state.run.character.maxHpBonus + gear.hp,
+      attackMultiplier: 1 + state.run.character.attackBonus + gear.attack,
+      defenseMultiplier: 1 + state.run.character.defenseBonus + gear.defense,
+    };
+  }
+
+  function generateNode(level) {
+    const type = level === 1 ? 'battle' : pick(['battle', 'battle', 'shop', 'rest']);
+    if (type === 'battle') {
+      const base = pick(ENEMY_POOL);
+      return { type, name: base.name, hp: base.hp + (level - 1) * 30 + Math.floor(Math.random() * 21), attack: base.attack + (level - 1) * 4 + Math.floor(Math.random() * 5) };
+    }
+    return type === 'shop' ? { type, name: '商店' } : { type, name: '營火休息' };
+  }
+
+  function createRoute() {
+    state.run.route = Array.from({ length: state.run.totalLevels }, (_, index) => generateNode(index + 1));
+    state.run.level = 1;
+    state.run.completed = false;
+    state.run.currentNode = state.run.route[0];
+  }
 
   function readNumberInput(id, fallback, { min = -Infinity, max = Infinity } = {}) {
     const raw = $(id).value;
@@ -162,13 +208,30 @@
     clearInterval(state.timerId); clearInterval(state.attackTimerId); clearInterval(state.enemyTimerId);
   }
 
+  function startNode(level = state.run.level) {
+    stopTimers();
+    state.run.level = level;
+    state.run.currentNode = state.run.route[level - 1] || generateNode(level);
+    const node = state.run.currentNode;
+    if (node.type === 'shop' || node.type === 'rest') {
+      state.ended = true;
+      render();
+      setStatus(node.type === 'shop' ? '抵達商店：可購買裝備，或直接前進。' : '抵達營火：可休息升級，或直接前進。');
+      return;
+    }
+    resetGame();
+    setStatus(`第 ${state.run.level} 關戰鬥：${node.name} 出現了！擊敗後可前進。`);
+  }
+
   function resetGame() {
     stopTimers();
     const size = readIntegerInput('boardSize', state.size || 8, { min: 3, max: 12 });
     const colorCount = readIntegerInput('colorCount', state.colorCount || 4, { min: 3, max: BLOCK_TYPES.length });
-    const playerMaxHp = readIntegerInput('playerMaxHpInput', state.playerMaxHp || 100, { min: 1, max: 9999 });
-    const enemyMaxHp = readIntegerInput('enemyMaxHpInput', state.enemyMaxHp || 100, { min: 1, max: 9999 });
-    Object.assign(state, { size, colorCount, fallSpeed: readNumberInput('fallSpeed', state.fallSpeed || 420, { min: 1, max: 5000 }), clearSpeed: readNumberInput('clearSpeed', state.clearSpeed || 260, { min: 1, max: 5000 }), attackInterval: readNumberInput('attackInterval', state.attackInterval || 5, { min: 1, max: 3600 }), enemyInterval: readNumberInput('enemyInterval', state.enemyInterval || 5, { min: 1, max: 3600 }), attackMultiplier: readNumberInput('attackMultiplier', state.attackMultiplier || 1, { min: 0, max: 999 }), defenseMultiplier: readNumberInput('defenseMultiplier', state.defenseMultiplier || 1, { min: 0, max: 999 }), enemyAttackPower: readNumberInput('enemyAttackPower', state.enemyAttackPower || 10, { min: 0, max: 9999 }), selected: null, busy: false, score: 0, moves: 30, combo: 1, currentTurnCombo: 0, lastComboCount: 0, startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null, hint: [], playerHp: playerMaxHp, enemyHp: enemyMaxHp, playerMaxHp, enemyMaxHp, nextPlayerAttackAt: null, nextEnemyAttackAt: null, lastAction: '交換方塊後，雙方攻擊計時器會開始。', heroAction: false, enemyAction: false, ended: false, magicArmed: false });
+    const hero = heroDerivedStats();
+    const node = state.run.currentNode && state.run.currentNode.type === 'battle' ? state.run.currentNode : { hp: readIntegerInput('enemyMaxHpInput', state.enemyMaxHp || 100, { min: 1, max: 9999 }), attack: readNumberInput('enemyAttackPower', state.enemyAttackPower || 10, { min: 0, max: 9999 }) };
+    const playerMaxHp = readIntegerInput('playerMaxHpInput', hero.maxHp, { min: 1, max: 9999 }) + hero.maxHp - 100;
+    const enemyMaxHp = node.hp;
+    Object.assign(state, { size, colorCount, fallSpeed: readNumberInput('fallSpeed', state.fallSpeed || 420, { min: 1, max: 5000 }), clearSpeed: readNumberInput('clearSpeed', state.clearSpeed || 260, { min: 1, max: 5000 }), attackInterval: readNumberInput('attackInterval', state.attackInterval || 5, { min: 1, max: 3600 }), enemyInterval: readNumberInput('enemyInterval', state.enemyInterval || 5, { min: 1, max: 3600 }), attackMultiplier: hero.attackMultiplier, defenseMultiplier: hero.defenseMultiplier, enemyAttackPower: node.attack, selected: null, busy: false, score: 0, moves: 30, combo: 1, currentTurnCombo: 0, lastComboCount: 0, startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null, hint: [], playerHp: playerMaxHp, enemyHp: enemyMaxHp, playerMaxHp, enemyMaxHp, nextPlayerAttackAt: null, nextEnemyAttackAt: null, lastAction: '交換方塊後，雙方攻擊計時器會開始。', heroAction: false, enemyAction: false, ended: false, magicArmed: false });
     resetRoundStats(state);
     state.board = logic.createBoard(state.size, state.colorCount);
     renderBlockSettings();
@@ -346,6 +409,43 @@
     }
   }
 
+  function completeNode() {
+    stopTimers();
+    state.run.gold += state.run.currentNode.type === 'battle' ? 15 + state.run.level * 5 : 0;
+    if (state.run.level >= state.run.totalLevels) {
+      state.run.completed = true;
+      state.ended = true;
+      setStatus('恭喜通關 3 關！可以開始新的冒險路線。');
+      render();
+      return;
+    }
+    startNode(state.run.level + 1);
+  }
+
+  function buyEquipment(index) {
+    const item = EQUIPMENT_SHOP[index];
+    if (!item || state.run.gold < item.price) return;
+    state.run.gold -= item.price;
+    state.run.equipment[item.slot] = item;
+    setStatus(`購買並裝備 ${item.name}。`);
+    render();
+  }
+
+  function restUpgrade() {
+    state.run.character.level++;
+    state.run.character.maxHpBonus += 20;
+    state.run.character.attackBonus += 0.1;
+    state.playerHp = heroDerivedStats().maxHp;
+    setStatus('營火休息：角色升級，生命與攻擊提升。');
+    render();
+  }
+
+  function newRun() {
+    state.run = window.Match3State.createRunState();
+    createRoute();
+    startNode(1);
+  }
+
   function showHint() {
     if (state.busy || state.ended) return;
     const move = logic.findAvailableMove(state.board);
@@ -357,11 +457,13 @@
 
   applyDebugOptionVisibility();
 
-  const renderer = window.Match3Renderer.createRenderer({ state, blockType, formatCountdown, countdownProgress, onCellClick: handleCellClick });
+  createRoute();
+
+  const renderer = window.Match3Renderer.createRenderer({ state, blockType, formatCountdown, countdownProgress, onCellClick: handleCellClick, onNextNode: completeNode, onBuyEquipment: buyEquipment, onRestUpgrade: restUpgrade, onNewRun: newRun, equipmentShop: EQUIPMENT_SHOP });
   render = renderer.render;
   renderBattleStats = renderer.renderBattleStats;
 
-  const battle = window.Match3Battle.createBattleSystem({ state, render, setStatus, clamp, sleepMsFromSeconds, stopTimers, resetRoundStats, formatNumber });
+  const battle = window.Match3Battle.createBattleSystem({ state, render, setStatus, clamp, sleepMsFromSeconds, stopTimers, resetRoundStats, formatNumber, onBattleWin: completeNode });
   playerAttack = battle.playerAttack;
   enemyAttack = battle.enemyAttack;
 
@@ -373,7 +475,7 @@
   $('resetButton').addEventListener('click', resetGame);
   $('hintButton').addEventListener('click', showHint);
   $('magicButton').addEventListener('click', useMagic);
-  resetGame();
+  startNode(1);
 
-  window.Match3Game = { state, resetGame, handleCellClick, resolveMatches, playerAttack, enemyAttack, showDebugOptions };
+  window.Match3Game = { state, resetGame, handleCellClick, resolveMatches, playerAttack, enemyAttack, showDebugOptions, completeNode, newRun };
 })();

--- a/assets/match3/state/game-state.js
+++ b/assets/match3/state/game-state.js
@@ -6,9 +6,33 @@
     return { attack: 0, defense: 0, spell: 0, heal: 0 };
   }
 
+  function createRunState() {
+    return {
+      level: 1,
+      totalLevels: 3,
+      gold: 35,
+      character: {
+        name: '冒險者',
+        level: 1,
+        maxHpBonus: 0,
+        attackBonus: 0,
+        defenseBonus: 0,
+      },
+      equipment: {
+        weapon: { name: '木劍', attack: 0 },
+        armor: { name: '布甲', defense: 0 },
+        charm: { name: '小護符', hp: 0 },
+      },
+      currentNode: null,
+      route: [],
+      completed: false,
+    };
+  }
+
   function createState() {
     return {
       board: [], size: 8, colorCount: 4, fallSpeed: 420, clearSpeed: 260,
+      run: createRunState(),
       selected: null, busy: false, score: 0, moves: 30, combo: 1,
       currentTurnCombo: 0, lastComboCount: 0,
       startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null,
@@ -24,5 +48,5 @@
     state.roundStats = createRoundStats();
   }
 
-  global.Match3State = { DEFAULT_HP, ENEMY_ATTACK, createState, createRoundStats, resetRoundStats };
+  global.Match3State = { DEFAULT_HP, ENEMY_ATTACK, createState, createRoundStats, createRunState, resetRoundStats };
 })(window);

--- a/assets/match3/systems/battle.js
+++ b/assets/match3/systems/battle.js
@@ -1,5 +1,5 @@
 (function (global) {
-  function createBattleSystem({ state, render, setStatus, clamp, sleepMsFromSeconds, stopTimers, resetRoundStats, formatNumber }) {
+  function createBattleSystem({ state, render, setStatus, clamp, sleepMsFromSeconds, stopTimers, resetRoundStats, formatNumber, onBattleWin }) {
     function showDamagePopup(target, amount, kind = 'damage') {
       const id = `${Date.now()}-${Math.random()}`;
       const prefix = kind === 'heal' ? '+' : '-';
@@ -19,7 +19,7 @@
     }
 
     function checkBattleEnd() {
-      if (state.enemyHp <= 0) { state.ended = true; stopTimers(); setStatus('勝利！敵方血量歸零。'); }
+      if (state.enemyHp <= 0) { state.ended = true; stopTimers(); setStatus('勝利！敵方血量歸零。'); if (typeof onBattleWin === 'function') onBattleWin(); return; }
       if (state.playerHp <= 0) { state.ended = true; stopTimers(); setStatus('失敗！我方血量歸零。'); }
       render();
     }

--- a/assets/match3/ui/render.js
+++ b/assets/match3/ui/render.js
@@ -11,7 +11,7 @@
     return parseFloat(root.getPropertyValue('--cell-size')) + parseFloat(root.getPropertyValue('--gap'));
   }
 
-  function createRenderer({ state, blockType, formatCountdown, countdownProgress, onCellClick }) {
+  function createRenderer({ state, blockType, formatCountdown, countdownProgress, onCellClick, onNextNode, onBuyEquipment, onRestUpgrade, onNewRun, equipmentShop = [] }) {
     function renderBattleStats() {
       const attack = state.roundStats.attack * state.attackMultiplier;
       const defense = state.roundStats.defense * state.defenseMultiplier;
@@ -43,6 +43,37 @@
       setBar('healMeter', heal, healMeterMax);
       $('magicButton').disabled = state.ended || state.magicArmed || state.roundStats.spell < 5;
       $('magicButton').textContent = state.magicArmed ? '魔法已準備：下次攻擊 x2' : '使用魔法（消耗 5 法術，下次攻擊 x2）';
+    }
+
+
+    function renderRunPanel() {
+      const panel = $('runPanel');
+      if (!panel) return;
+      const run = state.run;
+      const node = run.currentNode || {};
+      const route = run.route.map((step, index) => `<span class="route-node ${index + 1 === run.level ? 'current' : ''} ${index + 1 < run.level ? 'done' : ''}">${index + 1}. ${step.type === 'battle' ? '戰鬥' : step.type === 'shop' ? '商店' : '休息'}</span>`).join('');
+      const gear = Object.entries(run.equipment).map(([slot, item]) => `<li>${slot}: ${item.name}</li>`).join('');
+      const actions = node.type === 'shop'
+        ? `<div class="run-actions">${equipmentShop.map((item, index) => `<button type="button" data-shop-index="${index}" ${run.gold < item.price ? 'disabled' : ''}>買 ${item.name}（${item.price} 金）</button>`).join('')}<button type="button" data-next-node>離開商店</button></div>`
+        : node.type === 'rest'
+          ? `<div class="run-actions"><button type="button" data-rest-upgrade>休息升級</button><button type="button" data-next-node>前往下一關</button></div>`
+          : run.completed ? `<div class="run-actions"><button type="button" data-new-run>開始新冒險</button></div>` : '';
+      panel.innerHTML = `
+        <h2>冒險路線</h2>
+        <div class="route-list">${route}</div>
+        <p><strong>目前：</strong>第 ${run.level}/${run.totalLevels} 關 ${node.name || ''}${node.type === 'battle' ? `（HP ${node.hp} / 攻擊 ${node.attack}）` : ''}</p>
+        <p><strong>${run.character.name}</strong> Lv.${run.character.level}｜金幣 ${run.gold}</p>
+        <ul class="gear-list">${gear}</ul>
+        ${actions}
+      `;
+      if (!panel.querySelector) return;
+      panel.querySelectorAll('[data-shop-index]').forEach(button => button.addEventListener('click', event => onBuyEquipment(Number(event.target.dataset.shopIndex))));
+      const next = panel.querySelector('[data-next-node]');
+      if (next) next.addEventListener('click', onNextNode);
+      const rest = panel.querySelector('[data-rest-upgrade]');
+      if (rest) rest.addEventListener('click', onRestUpgrade);
+      const newRun = panel.querySelector('[data-new-run]');
+      if (newRun) newRun.addEventListener('click', onNewRun);
     }
 
     function render(options = {}) {
@@ -131,6 +162,7 @@
       $('hintButton').disabled = state.busy || state.ended;
       $('resetButton').disabled = state.busy;
       renderBattleStats();
+      renderRunPanel();
     }
 
     return { render, renderBattleStats };

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <main class="app-shell">
     <section class="hero">
       <p class="eyebrow">Match-3 Puzzle Game</p>
-      <h1>簡易三消遊戲</h1>
-      <p class="subtitle">點選相鄰方塊交換，湊成 3 個以上同色方塊即可消除。現在每種方塊都有戰鬥效果，並會依照雙方攻擊計時器進行結算。</p>
+      <h1>三消爬塔冒險</h1>
+      <p class="subtitle">點選相鄰方塊交換並用三消進行戰鬥。現在加入 3 關冒險路線，途中可能遇到隨機敵人、商店或休息升級，裝備會影響角色基礎數值。</p>
     </section>
 
     <section class="panel controls" aria-label="遊戲設定">
@@ -66,6 +66,8 @@
       <button id="resetButton" type="button">重設遊戲</button>
       <button id="hintButton" type="button" class="secondary">提示</button>
     </section>
+
+    <section id="runPanel" class="panel run-panel" aria-label="冒險路線"></section>
 
     <section class="stats" aria-label="遊戲狀態">
       <article><span>分數</span><strong id="score">0</strong></article>

--- a/test/match3.test.js
+++ b/test/match3.test.js
@@ -103,9 +103,10 @@ function assertBoardPanelRendered(elements, expectedSize, message) {
   const { context, elements, scriptFiles } = createHarness();
 
   assertBoardPanelRendered(elements, 8, 'initial load');
-  assert.equal(elements.status.textContent, '請交換相鄰方塊開始遊戲。');
+  assert.match(elements.status.textContent, /第 1 關戰鬥：.+出現了！擊敗後可前進。/);
   assert.equal(elements.playerHp.textContent, '120/120');
-  assert.equal(elements.enemyHp.textContent, '150/150');
+  assert.match(elements.enemyHp.textContent, /\d+\/\d+/);
+  assert.match(elements.runPanel.innerHTML, /冒險路線/);
   assert.equal(elements.moves.textContent, 30);
   assert.equal(elements.healValue.textContent, '0 / 100', 'heal should have an accumulation meter');
   assert.equal(context.window.Match3Game.showDebugOptions, false, 'debug option controls should be hidden by default');
@@ -188,6 +189,8 @@ function assertBoardPanelRendered(elements, expectedSize, message) {
   context.window.Match3Game.state.attackMultiplier = 2;
   context.window.Match3Game.state.lastComboCount = 2;
   context.window.Match3Game.state.playerHp = 110;
+  context.window.Match3Game.state.enemyMaxHp = 150;
+  context.window.Match3Game.state.enemyHp = 150;
   context.window.Match3Game.playerAttack();
   assert.equal(context.window.Match3Game.state.enemyHp, 133.06, 'player attack should apply attack blocks times 1.1^combo times attack power');
   assert.equal(context.window.Match3Game.state.playerHp, 115, 'player attack should apply accumulated healing to the hero');


### PR DESCRIPTION
### Motivation
- Introduce a simple roguelite/`Slay-the-Spire`-style layer so runs contain multiple nodes (battle/shop/rest) and player progression across levels. 
- Allow equipment and character upgrades to affect base stats (HP/attack/defense) and make each run feel like build/choice gameplay. 

### Description
- Documented the pre-roguelite baseline in `README.md` with the baseline commit `3c9e368bcf444829c34d08ac6a49ffde2040dc48` for future rollback. 
- Added run state and helpers in `assets/match3/state/game-state.js` via `createRunState()` and integrated it into the global `createState()` object as `state.run`. 
- Implemented node generation, enemy/equipment pools, and hero-derived stats in `assets/match3/main.js` (`ENEMY_POOL`, `EQUIPMENT_SHOP`, `generateNode`, `createRoute`, `heroDerivedStats`, `equipmentTotals`, `startNode`, `completeNode`, `buyEquipment`, `restUpgrade`, `newRun`) and wired node-aware `resetGame()` to apply character/equipment modifiers. 
- Hooked battle outcome into progression by adding an `onBattleWin` callback to the battle system (`assets/match3/systems/battle.js`) and invoking `completeNode()` on victory. 
- Added a run UI panel and renderer hooks in `assets/match3/ui/render.js` (rendering route, current node, gear, and actionable shop/rest buttons) and added `#runPanel` markup and copy changes in `index.html`. 
- Added minimal styles in `assets/match3.css` and updated the regression test `test/match3.test.js` to expect the new initial run state. 

### Testing
- Ran `node --test` which executes `test/match3.test.js` and the suite passed. 
- Ran `git diff --check` to ensure no whitespace/format issues and it passed. 
- Updated test expectations in `test/match3.test.js` to reflect the new run UI and initial node; the modified test passed under `node --test`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33532dfb088332bde3d616ef7efef6)