### PR TITLE
Add enemy board-lock mechanic and consolidate battle UI

### DIFF
--- a/assets/match3.css
+++ b/assets/match3.css
@@ -130,3 +130,26 @@ button:disabled { opacity: .55; cursor: not-allowed; }
 .run-actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
 .run-actions button { background: #7c3aed; }
 .run-actions button[data-next-node] { background: #2563eb; }
+.cell.locked {
+  cursor: not-allowed;
+  border-color: #0f172a;
+  filter: grayscale(.35) brightness(.8);
+  box-shadow: inset 0 -7px 0 rgba(0,0,0,.2), 0 0 0 4px rgba(15,23,42,.55), 0 10px 18px rgba(15,23,42,.26);
+  animation: lock-pulse 1.15s ease-in-out infinite;
+}
+.cell.locked::after {
+  content: '🔒';
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  border-radius: inherit;
+  background: repeating-linear-gradient(135deg, rgba(15,23,42,.42) 0 6px, rgba(255,255,255,.14) 6px 12px);
+  color: #f8fafc;
+  font-size: 20px;
+  text-shadow: 0 2px 3px rgba(0,0,0,.75);
+  z-index: 2;
+}
+.locked-summary { margin: 0 0 12px; padding: 10px; border-radius: 12px; background: #f1f5f9; border: 1px solid #cbd5e1; font-weight: 800; }
+.stat-compact { display: none; }
+@keyframes lock-pulse { 50% { transform: scale(.96); box-shadow: inset 0 -7px 0 rgba(0,0,0,.2), 0 0 0 5px rgba(59,130,246,.45); } }

--- a/assets/match3/main.js
+++ b/assets/match3/main.js
@@ -149,6 +149,37 @@
   }
 
   function posKey(pos) { return `${pos.r},${pos.c}`; }
+  function isLocked(pos) { return state.lockedCells.includes(posKey(pos)); }
+  function setLockedCells(cells) { state.lockedCells = Array.from(new Set(cells.map(posKey))); }
+  function unlockCells(cells) {
+    if (!state.lockedCells.length || !cells.length) return 0;
+    const unlock = new Set(cells.map(posKey));
+    const before = state.lockedCells.length;
+    state.lockedCells = state.lockedCells.filter(key => !unlock.has(key));
+    return before - state.lockedCells.length;
+  }
+  function adjacentCells(pos) {
+    return [{ r: pos.r - 1, c: pos.c }, { r: pos.r + 1, c: pos.c }, { r: pos.r, c: pos.c - 1 }, { r: pos.r, c: pos.c + 1 }]
+      .filter(cell => cell.r >= 0 && cell.c >= 0 && cell.r < state.size && cell.c < state.size);
+  }
+  function unlockAround(cells) {
+    const targets = [];
+    cells.forEach(cell => adjacentCells(cell).forEach(next => targets.push(next)));
+    return unlockCells(targets);
+  }
+  function findAvailableUnlockedMove() {
+    for (let r = 0; r < state.size; r++) {
+      for (let c = 0; c < state.size; c++) {
+        const first = { r, c };
+        if (isLocked(first)) continue;
+        for (const second of [{ r: r + 1, c }, { r, c: c + 1 }]) {
+          if (second.r >= state.size || second.c >= state.size || isLocked(second)) continue;
+          if (logic.findMatches(logic.swap(state.board, first, second)).length > 0) return [first, second];
+        }
+      }
+    }
+    return null;
+  }
 
   function specialName(special) {
     return special === 'line-row' ? '橫列消除' : special === 'line-column' ? '直行消除' : special === 'bomb' ? '九宮格爆炸' : '同色全消';
@@ -300,7 +331,7 @@
     const playerMaxHp = readIntegerInput('playerMaxHpInput', hero.maxHp, { min: 1, max: 9999 }) + hero.maxHp - 100;
     const enemyMaxHp = node.enemy ? node.enemy.hp : readIntegerInput('enemyMaxHpInput', state.enemyMaxHp || 100, { min: 1, max: 9999 });
     applyLevelBlockWeights(node);
-    Object.assign(state, { size, colorCount, fallSpeed: readNumberInput('fallSpeed', state.fallSpeed || 420, { min: 1, max: 5000 }), clearSpeed: readNumberInput('clearSpeed', state.clearSpeed || 260, { min: 1, max: 5000 }), attackInterval: readNumberInput('attackInterval', state.attackInterval || 5, { min: 1, max: 3600 }), enemyInterval: node.enemy ? node.enemy.attackInterval : readNumberInput('enemyInterval', state.enemyInterval || 5, { min: 1, max: 3600 }), attackMultiplier: hero.attackMultiplier, defenseMultiplier: hero.defenseMultiplier, enemyAttackPower: node.enemy ? node.enemy.attack : readNumberInput('enemyAttackPower', state.enemyAttackPower || 10, { min: 0, max: 9999 }), selected: null, busy: false, score: 0, moves: node.moves || 30, combo: 1, currentTurnCombo: 0, lastComboCount: 0, playerAttackThreshold: 10, startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null, hint: [], playerHp: playerMaxHp, enemyHp: enemyMaxHp, playerMaxHp, enemyMaxHp, nextPlayerAttackAt: null, nextEnemyAttackAt: null, lastAction: '交換方塊後，敵方攻擊計時器會開始；我方累積 10 個攻擊方塊後出手。', heroAction: false, enemyAction: false, ended: false, magicArmed: false });
+    Object.assign(state, { size, colorCount, fallSpeed: readNumberInput('fallSpeed', state.fallSpeed || 420, { min: 1, max: 5000 }), clearSpeed: readNumberInput('clearSpeed', state.clearSpeed || 260, { min: 1, max: 5000 }), attackInterval: readNumberInput('attackInterval', state.attackInterval || 5, { min: 1, max: 3600 }), enemyInterval: node.enemy ? node.enemy.attackInterval : readNumberInput('enemyInterval', state.enemyInterval || 5, { min: 1, max: 3600 }), attackMultiplier: hero.attackMultiplier, defenseMultiplier: hero.defenseMultiplier, enemyAttackPower: node.enemy ? node.enemy.attack : readNumberInput('enemyAttackPower', state.enemyAttackPower || 10, { min: 0, max: 9999 }), selected: null, busy: false, score: 0, moves: node.moves || 30, combo: 1, currentTurnCombo: 0, lastComboCount: 0, playerAttackThreshold: 10, startedAt: null, timerId: null, attackTimerId: null, enemyTimerId: null, hint: [], playerHp: playerMaxHp, enemyHp: enemyMaxHp, playerMaxHp, enemyMaxHp, nextPlayerAttackAt: null, nextEnemyAttackAt: null, lastAction: '交換方塊後，敵方攻擊計時器會開始；我方累積 10 個攻擊方塊後出手。', heroAction: false, enemyAction: false, ended: false, magicArmed: false, lockedCells: [] });
     resetRoundStats(state);
     state.board = logic.createBoard(state.size, state.colorCount);
     renderBlockSettings();
@@ -314,6 +345,7 @@
     if (state.busy || state.moves <= 0 || state.ended) return;
     state.hint = [];
     const clickedBlock = state.board[pos.r][pos.c];
+    if (isLocked(pos)) { setStatus('這個方塊被敵人封鎖，需用特殊方塊或消除旁邊方塊解除。'); return; }
     if (!state.selected && logic.isSpecialBlock(clickedBlock)) {
       startTimers();
       beginPlayerOperation();
@@ -330,6 +362,7 @@
     }
     if (!state.selected) { state.selected = pos; render(); return; }
     if (!logic.areAdjacent(state.selected, pos)) { state.selected = pos; render(); return; }
+    if (isLocked(state.selected) || isLocked(pos)) { state.selected = null; setStatus('被封鎖的方塊不能交換。'); render(); return; }
 
     const selectedBlock = state.board[state.selected.r][state.selected.c];
     if (logic.isSpecialBlock(selectedBlock) && logic.isSpecialBlock(clickedBlock)) {
@@ -405,12 +438,16 @@
     const waitMs = cells.reduce((duration, { r, c }) => Math.max(duration, blockClearSpeed(state.board[r][c])), state.clearSpeed);
     render({ clearing: cells });
     await sleep(waitMs);
+    const lockedBeforeClear = new Set(state.lockedCells || []);
+    const unlockedBySpecial = unlockCells(cells);
     cells.forEach(({ r, c }) => {
-      if (state.board[r][c] === null) return;
+      if (state.board[r][c] === null || lockedBeforeClear.has(posKey({ r, c }))) return;
       const type = blockType(logic.colorOf(state.board[r][c]));
       state.roundStats[type.stat] += 1;
       state.board[r][c] = null;
     });
+    const unlockedAround = unlockAround(cells);
+    if (unlockedBySpecial + unlockedAround > 0) state.lastAction = `解除 ${unlockedBySpecial + unlockedAround} 個封鎖方塊。`;
     const collapsed = logic.collapse(state.board, state.colorCount);
     state.board = collapsed.board;
     render({ fallMoves: collapsed.fallMoves, spawnMoves: collapsed.spawnMoves });
@@ -474,7 +511,7 @@
   function endTurnCheck() {
     if (state.ended) return;
     if (state.moves <= 0) { setStatus('步數用完，請重設再挑戰一次。'); return; }
-    if (!logic.findAvailableMove(state.board)) {
+    if (!findAvailableUnlockedMove()) {
       state.board = logic.shuffleBoard(state.board);
       setStatus('棋盤沒有可走步了，已自動重排。');
     } else {
@@ -521,7 +558,7 @@
 
   function showHint() {
     if (state.busy || state.ended) return;
-    const move = logic.findAvailableMove(state.board);
+    const move = findAvailableUnlockedMove();
     state.hint = move || [];
     setStatus(move ? '已標出一組可交換的方塊。' : '目前無解，已重新排列棋盤。');
     if (!move) state.board = logic.shuffleBoard(state.board);
@@ -536,7 +573,30 @@
   render = renderer.render;
   renderBattleStats = renderer.renderBattleStats;
 
-  const battle = window.Match3Battle.createBattleSystem({ state, render, setStatus, clamp, sleepMsFromSeconds, stopTimers, resetRoundStats, formatNumber, onBattleWin: completeNode, onAfterPlayerAttack: applyBossPhaseIfNeeded });
+  function onEnemyBoardLock() {
+    if (state.ended || !state.board.length) return;
+    const candidates = [];
+    state.board.forEach((row, r) => row.forEach((value, c) => {
+      const pos = { r, c };
+      if (value !== null && !isLocked(pos) && !logic.isSpecialBlock(value)) candidates.push(pos);
+    }));
+    const count = Math.min(3, Math.max(1, Math.floor(state.size / 3)), candidates.length);
+    const picked = [];
+    while (picked.length < count && candidates.length) {
+      const index = Math.floor(Math.random() * candidates.length);
+      picked.push(candidates.splice(index, 1)[0]);
+    }
+    setLockedCells([...state.lockedCells.map(key => { const [r, c] = key.split(',').map(Number); return { r, c }; }), ...picked]);
+    if (!findAvailableUnlockedMove()) {
+      unlockCells(picked);
+      state.lastAction += ' 敵人想封鎖版面，但保留至少一組可走步。';
+    } else if (picked.length) {
+      state.lastAction += ` 敵人封鎖 ${picked.length} 個方塊，可用特殊方塊或消除旁邊方塊解除。`;
+    }
+    render();
+  }
+
+  const battle = window.Match3Battle.createBattleSystem({ state, render, setStatus, clamp, sleepMsFromSeconds, stopTimers, resetRoundStats, formatNumber, onBattleWin: completeNode, onAfterPlayerAttack: applyBossPhaseIfNeeded, onEnemyBoardLock });
   playerAttack = battle.playerAttack;
   enemyAttack = battle.enemyAttack;
 

--- a/assets/match3/state/game-state.js
+++ b/assets/match3/state/game-state.js
@@ -40,7 +40,7 @@
       attackMultiplier: 1, defenseMultiplier: 1, enemyAttackPower: ENEMY_ATTACK,
       attackInterval: 5, enemyInterval: 5, nextPlayerAttackAt: null, nextEnemyAttackAt: null,
       roundStats: createRoundStats(),
-      lastAction: '尚未攻擊。', heroAction: false, enemyAction: false, damagePopups: [], ended: false, magicArmed: false
+      lastAction: '尚未攻擊。', heroAction: false, enemyAction: false, damagePopups: [], ended: false, magicArmed: false, lockedCells: []
     };
   }
 

--- a/assets/match3/systems/battle.js
+++ b/assets/match3/systems/battle.js
@@ -1,5 +1,5 @@
 (function (global) {
-  function createBattleSystem({ state, render, setStatus, clamp, sleepMsFromSeconds, stopTimers, resetRoundStats, formatNumber, onBattleWin, onAfterPlayerAttack }) {
+  function createBattleSystem({ state, render, setStatus, clamp, sleepMsFromSeconds, stopTimers, resetRoundStats, formatNumber, onBattleWin, onAfterPlayerAttack, onEnemyBoardLock }) {
     function showDamagePopup(target, amount, kind = 'damage') {
       const id = `${Date.now()}-${Math.random()}`;
       const prefix = kind === 'heal' ? '+' : '-';
@@ -63,6 +63,7 @@
       if (damage > 0) showDamagePopup('hero', damage);
       state.roundStats.defense = defenseBeforeDecay / 2;
       state.lastAction = `敵方攻擊 ${formatNumber(state.enemyAttackPower)}，防禦方塊抵擋 ${formatNumber(blocked)}，我方受到 ${formatNumber(damage)} 傷害。防禦半衰期：${formatNumber(defenseBeforeDecay)} → ${formatNumber(state.roundStats.defense)}。`;
+      if (typeof onEnemyBoardLock === 'function') onEnemyBoardLock();
       state.nextEnemyAttackAt = Date.now() + sleepMsFromSeconds(state.enemyInterval);
       flashActor('enemy');
       checkBattleEnd();

--- a/assets/match3/ui/render.js
+++ b/assets/match3/ui/render.js
@@ -85,6 +85,7 @@
       const falling = new Map((options.fallMoves || []).map(move => [key(move.to), move.distance]));
       const spawning = new Map((options.spawnMoves || []).map(move => [key(move.to), move.distance]));
       const hint = new Set(state.hint.map(key));
+      const locked = new Set((state.lockedCells || []));
       const boardEl = $('board');
       boardEl.style.setProperty('--board-size', state.size);
       boardEl.style.setProperty('--fall-duration', `${state.fallSpeed}ms`);
@@ -112,6 +113,11 @@
           div.innerHTML = `<span class="cell-icon" aria-hidden="true">${type.icon}</span>${specialIcon ? `<span class="special-icon" aria-hidden="true">${specialIcon}</span>` : ''}`;
           div.title = isSpecial ? `${type.name}特殊方塊：${specialIcon}` : type.name;
           div.addEventListener('click', () => onCellClick(pos));
+        }
+        if (locked.has(key(pos))) {
+          div.classList.add('locked');
+          div.setAttribute('aria-label', `${div.attributes['aria-label']}（被封鎖）`);
+          div.title = `${div.title || '方塊'}（被封鎖：用特殊方塊或消除周圍解除）`;
         }
         if (state.selected && state.selected.r === r && state.selected.c === c) div.classList.add('selected');
         if (clearing.has(key(pos))) {
@@ -147,6 +153,9 @@
       $('roundDefense').textContent = state.roundStats.defense;
       $('roundSpell').textContent = state.roundStats.spell;
       $('roundHeal').textContent = state.roundStats.heal;
+      const lockedCount = (state.lockedCells || []).length;
+      const lockedCountEl = $('lockedCount');
+      if (lockedCountEl) lockedCountEl.textContent = lockedCount;
       $('battleLog').textContent = state.lastAction;
       const heroFighter = $('heroSprite').parentElement;
       const enemyFighter = $('enemySprite').parentElement;

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <section class="hero">
       <p class="eyebrow">Match-3 Puzzle Game</p>
       <h1>三消爬塔冒險</h1>
-      <p class="subtitle">點選相鄰方塊交換並用三消進行戰鬥。現在加入 3 關冒險路線，途中可能遇到隨機敵人、商店或休息升級，裝備會影響角色基礎數值。</p>
+      <p class="subtitle">點選相鄰方塊交換並用三消進行戰鬥。敵人攻擊後可能封鎖方塊；用特殊方塊或消除旁邊方塊就能解除。</p>
     </section>
 
     <section class="panel controls" aria-label="遊戲設定">
@@ -74,9 +74,9 @@
       <article><span>步數</span><strong id="moves">30</strong></article>
       <article><span>時間</span><strong id="timer">00:00</strong></article>
       <article><span>連擊</span><strong id="combo">連擊 0</strong></article>
-      <article><span>我方血量</span><strong id="playerHp">100/100</strong></article>
-      <article><span>敵方血量</span><strong id="enemyHp">100/100</strong></article>
-      <article><span>我方攻擊累積</span><strong id="playerAttackCountdown">0 / 10</strong></article>
+      <article class="stat-compact"><span>我方血量</span><strong id="playerHp">100/100</strong></article>
+      <article class="stat-compact"><span>敵方血量</span><strong id="enemyHp">100/100</strong></article>
+      <article class="stat-compact"><span>我方攻擊累積</span><strong id="playerAttackCountdown">0 / 10</strong></article>
       <article><span>敵方攻擊</span><strong id="enemyAttackCountdown">--</strong></article>
     </section>
 
@@ -155,12 +155,14 @@
           <span>✦ 法術 <strong id="roundSpell">0</strong></span>
           <span>❤ 回血 <strong id="roundHeal">0</strong></span>
         </div>
+        <p class="locked-summary">🔒 封鎖方塊 <strong id="lockedCount">0</strong> 個</p>
         <ul>
           <li>預設方塊效果：攻擊、防禦、法術、回血。</li>
           <li>連擊數會記錄玩家最後一次操作後，總共觸發了幾次消除。</li>
           <li>提示按鈕會標出目前可交換、且交換後能形成三消的一組相鄰方塊。</li>
           <li>我方累積 10 個攻擊方塊才會攻擊；若還在連擊或方塊下落，會等整段消除結束後才出手。</li>
           <li>敵方攻擊時間到時，防禦會抵消敵方攻擊；每次敵方計時器重置後，累積防禦會砍半。</li>
+          <li>敵人攻擊會隨機封鎖方塊；被封鎖方塊不能交換，用特殊方塊或消除旁邊方塊可解除。</li>
         </ul>
         <p id="battleLog" class="battle-log">尚未攻擊。</p>
         <p id="status" class="status">請交換相鄰方塊開始遊戲。</p>


### PR DESCRIPTION
### Motivation
- Add a new challenge where enemy attacks can lock some board cells so they cannot be swapped, and require special blocks or clearing adjacent cells to unlock. 
- Make the UI more focused by removing duplicated top-level stats already shown in the battle panel and surface the locked-cell count in the battle area. 

### Description
- Added `lockedCells` to game state and utility helpers `isLocked`, `setLockedCells`, `unlockCells`, `unlockAround`, `adjacentCells`, and `findAvailableUnlockedMove` to manage locked tiles and ensure at least one playable unlocked move remains. (`assets/match3/state/game-state.js`, `assets/match3/main.js`).
- Prevent swapping/selection of locked tiles and make special-block activation or clearing adjacent cells unlock locked tiles; clears now account for locked tiles when accumulating effects. (`assets/match3/main.js`).
- Hooked board-lock behavior into the enemy attack flow by calling a new `onEnemyBoardLock` callback after `enemyAttack`, which randomly locks normal blocks but ensures a playable move remains. (`assets/match3/systems/battle.js`, `assets/match3/main.js`).
- Render locked tiles with a visible lock effect and update the renderer to mark locked cells and show `lockedCount` in the battle panel, and adjust hint/available-move logic to respect locked cells. (`assets/match3/ui/render.js`, `assets/match3.css`, `index.html`).
- Tidy UI: hide duplicated compact top-status items in the top stats bar (they remain visible in the battle panel) and add explanatory text for the new lock mechanic. (`index.html`, `assets/match3/css`).

### Testing
- Ran `node --test` which executes `test/match3.test.js` and it passed (`match3 basic UI tests passed`).
- Ran `git diff --check` which returned no issues after trimming trailing whitespace. 
- Attempted an automated screenshot via Playwright but the environment did not have Playwright installed, so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33a475a53083328bcd2896cd960d6f)